### PR TITLE
Weekly build - September, 7th, 2016

### DIFF
--- a/ginger/centOS/7.2/ginger.spec
+++ b/ginger/centOS/7.2/ginger.spec
@@ -4,7 +4,7 @@
 
 Name:       ginger
 Version:    2.2.0
-Release:    2%{?dist}%{?pkvm_release}
+Release:    3%{?dist}%{?pkvm_release}
 Summary:    Host management plugin for Wok - Webserver Originated from Kimchi
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 Group:      System Environment/Base
@@ -99,6 +99,21 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Sep 07 2016 user - 2.2.0-3.pkvm3_1_1
+- 086765c Update functionalities for Platform Management
+30cefe3 UT implemented for the new features implemented.
+fbd22ff Audit graph backend implemetation.
+0fc004a Audit predefined rules backend implementation.
+e093afb Updated docs and i18n.py for the new features implemented.
+d4101d1 Backend code implemented to get list of system calls.
+c1d2fd7 Audit report implementation from the backend.
+630bfae Audit log implementation from the backend.
+bdea605 Audit conf implemented in the backend.
+1c528ad Modified audit rules code for comments and added new features.
+fe4324f Issue #166 : nfs mount fails with 500
+ee3d989 Backend Changes for Sensor Data Records for Platform Management
+670ff8c [HostOS] Revert Introducing iSCSI implementation for Storage devices
+
 * Thu Sep 01 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.2.0-2.pkvm3_1_1
 - Build August, 31st, 2016
 

--- a/ginger/ginger.yaml
+++ b/ginger/ginger.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'ginger'
  clone_url: 'https://github.com/open-power-host-os/ginger.git'
  branch: 'powerkvm-v3.1.1'
- commit_id: '670ff8c'
+ commit_id: '086765c'
  expects_source: 'ginger'
  files:
   centos:

--- a/gingerbase/centOS/7.2/gingerbase.spec
+++ b/gingerbase/centOS/7.2/gingerbase.spec
@@ -8,7 +8,7 @@
 
 Name:       ginger-base
 Version:    2.0.0
-Release:    2%{?dist}%{?pkvm_release}
+Release:    3%{?dist}%{?pkvm_release}
 Summary:    Wok plugin for base host management
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch
@@ -75,6 +75,11 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Sep 07 2016 user - 2.0.0-3.pkvm3_1_1
+- b51c6ae Extending Kimchi Peers to Host Dashboard
+6875c55 Moving storage device listing from ginger to gingerbase
+2fa4618 Update usage of add_task() method.
+
 * Thu Sep 01 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.0.0-2.pkvm3_1_1
 - Build August, 31st, 2016
 

--- a/gingerbase/gingerbase.yaml
+++ b/gingerbase/gingerbase.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'gingerbase'
  clone_url: 'https://github.com/open-power-host-os/gingerbase.git'
  branch: 'powerkvm-v3.1.1'
- commit_id: '2fa4618'
+ commit_id: 'b51c6ae'
  expects_source: 'ginger-base'
  files:
   centos:

--- a/kimchi/centOS/7.2/kimchi.spec
+++ b/kimchi/centOS/7.2/kimchi.spec
@@ -4,7 +4,7 @@
 
 Name:       kimchi
 Version:    2.2.0
-Release:    2%{?dist}%{?pkvm_release}
+Release:    3%{?dist}%{?pkvm_release}
 Summary:    Kimchi server application
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch
@@ -94,6 +94,26 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Sep 07 2016 user - 2.2.0-3.pkvm3_1_1
+- 484cab8 Storagebuttons not behaving properly
+6c2249e Create test to verify graphics type change
+dfb11f2 Issue #836: Allow user change guest graphics type
+8ce6506 Issue #994: SPICE graphics does not need <channel> tag
+2f5e538 For s390x architecture, serial type is not validated in vm xml as as not supported on s390x.
+0889977 Issue# 973 Emphasize resource name in dlg
+2bcb669 Updated API.md for addition paramters support for VM ifaces API on s390x/s390 architecture.
+b2371dc Updated code to support VM ifaces on s390x/s390 architecture.
+bdd88ad Updated API.md for addition interfaces paramter in template API.
+fd39978 Updated code to support interfaces parameter to template API only on s390x/s390 architecture.
+189f53b /plugins/kimchi/ovsbridges API
+2285616 Issue #606: Change icon to distinguish image generated template and iso generated template
+c7e9307 Issue #939: [UI] Guest tab is not rendered correctly if guests are not in running or shutoff state
+8ad9319 Issue #921: Peers button disappears
+30ce46d Enhancement to /plugins/kimchi/interfaces
+b6eb399 Enhancement to /plugins/kimchi/interfaces
+5a6b9a0 Issue #626: Snapshot revert does not release storage volume
+12fe984 Attach all functions of multi-fn PCI PT at once
+
 * Thu Sep 01 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.2.0-2.pkvm3_1_1
 - Build August, 31st, 2016
 

--- a/kimchi/kimchi.yaml
+++ b/kimchi/kimchi.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'kimchi'
  clone_url: 'https://github.com/open-power-host-os/kimchi.git'
  branch: 'powerkvm-v3.1.1'
- commit_id: '12fe984'
+ commit_id: '484cab8'
  expects_source: 'kimchi'
  files:
   centos:

--- a/wok/centOS/7.2/wok.spec
+++ b/wok/centOS/7.2/wok.spec
@@ -4,7 +4,7 @@
 
 Name:       wok
 Version:    2.2.0
-Release:    3%{?dist}%{?pkvm_release}
+Release:    4%{?dist}%{?pkvm_release}
 Summary:    Wok - Webserver Originated from Kimchi
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch
@@ -178,6 +178,20 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Wed Sep 07 2016 user - 2.2.0-4.pkvm3_1_1
+- bea70fc Merge remote-tracking branch upstream/master into powerkvm-v3.1.1
+8e5a84d Change location of User Requests Log
+d164293 Save log entry IDs for requests that generate tasks
+2ae31d2 Log AsyncTask success or failure
+d25d822 Update Request Logger to handle AsyncTask status
+0767b4b Create log_request() method for code simplification
+cdb3c4e Blink dialog session timeout
+86514d0 Minor fixes in form fields
+bc54058 Removing Kimchi Peers dropdown from Wok navbar
+b1f0fef Issue #122 - Add unit test to stop AsyncTask.
+9a00bff Issue #122 - Make AsyncTask stoppable.
+240f449 Merge remote-tracking branch upstream/master into powerkvm-v3.1.1
+
 * Thu Sep 01 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.2.0-3.pkvm3_1_1
 - Build August, 31st, 2016
 

--- a/wok/wok.yaml
+++ b/wok/wok.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'wok'
  clone_url: 'https://github.com/open-power-host-os/wok.git'
  branch: 'powerkvm-v3.1.1'
- commit_id: '240f449'
+ commit_id: 'bea70fc'
  expects_source: 'wok'
  files:
   centos:


### PR DESCRIPTION
 * Ginger changed from 670ff8c to 086765c:
```
086765c Update functionalities for Platform Management
30cefe3 UT implemented for the new features implemented.
fbd22ff Audit graph backend implemetation.
0fc004a Audit predefined rules backend implementation.
e093afb Updated docs and i18n.py for the new features implemented.
d4101d1 Backend code implemented to get list of system calls.
c1d2fd7 Audit report implementation from the backend.
630bfae Audit log implementation from the backend.
bdea605 Audit conf implemented in the backend.
1c528ad Modified audit rules code for comments and added new features.
fe4324f Issue #166 : nfs mount fails with 500
ee3d989 Backend Changes for Sensor Data Records for Platform Management
670ff8c [HostOS] Revert Introducing iSCSI implementation for Storage devices
```

* ginger-base changed from 2fa4618 to b51c6ae
```
b51c6ae Extending Kimchi Peers to Host Dashboard
6875c55 Moving storage device listing from ginger to gingerbase
2fa4618 Update usage of add_task() method.
```

* kimchi changed from 12fe984 to 484cab8
```
484cab8 Storagebuttons not behaving properly
6c2249e Create test to verify graphics type change
dfb11f2 Issue #836: Allow user change guest graphics type
8ce6506 Issue #994: SPICE graphics does not need <channel> tag
2f5e538 For s390x architecture, serial type is not validated in vm xml as as not supported on s390x.
0889977 Issue# 973 Emphasize resource name in dlg
2bcb669 Updated API.md for addition paramters support for VM ifaces API on s390x/s390 architecture.
b2371dc Updated code to support VM ifaces on s390x/s390 architecture.
bdd88ad Updated API.md for addition interfaces paramter in template API.
fd39978 Updated code to support interfaces parameter to template API only on s390x/s390 architecture.
189f53b /plugins/kimchi/ovsbridges API
2285616 Issue #606: Change icon to distinguish image generated template and iso generated template
c7e9307 Issue #939: [UI] Guest tab is not rendered correctly if guests are not in running or shutoff state
8ad9319 Issue #921: Peers button disappears
30ce46d Enhancement to /plugins/kimchi/interfaces
b6eb399 Enhancement to /plugins/kimchi/interfaces
5a6b9a0 Issue #626: Snapshot revert does not release storage volume
12fe984 Attach all functions of multi-fn PCI PT at once
```

* Wok changed from 240f449 to bea70fc
```
bea70fc Merge remote-tracking branch upstream/master into powerkvm-v3.1.1
8e5a84d Change location of User Requests Log
d164293 Save log entry IDs for requests that generate tasks
2ae31d2 Log AsyncTask success or failure
d25d822 Update Request Logger to handle AsyncTask status
0767b4b Create log_request() method for code simplification
cdb3c4e Blink dialog session timeout
86514d0 Minor fixes in form fields
bc54058 Removing Kimchi Peers dropdown from Wok navbar
b1f0fef Issue #122 - Add unit test to stop AsyncTask.
9a00bff Issue #122 - Make AsyncTask stoppable.
240f449 Merge remote-tracking branch upstream/master into powerkvm-v3.1.1
```