### PR TITLE
Package numbering cleanup in kernel.spec

### DIFF
--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -409,7 +409,7 @@ BuildRequires: ncurses-devel
 %endif
 
 #Source0: linux-%{rpmversion}-%{specrelease}.el7.tar.xz
-Source0: kernel-0.tar.gz
+Source0: kernel.tar.gz
 
 Source11: x509.genkey
 
@@ -710,7 +710,7 @@ exit 1
 %endif
 
 tar xzf %{SOURCE0}
-mv kernel-0 kernel-%{KVRA}
+mv kernel kernel-%{KVRA}
 #setup -q -n kernel-%{rheltarball} -c
 
 

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -21,15 +21,12 @@ Summary: The Linux kernel
 %global released_kernel 1
 
 %define rpmversion 4.8.1
-%define pkgrelease 1
-
-# allow pkg_release to have configurable %{?dist} tag
 %define specrelease 2
 
 %define pkg_release %{specrelease}%{?dist}
 
 # The kernel tarball/base version
-#define rheltarball %{rpmversion}-%{pkgrelease}.el7
+#define rheltarball %{rpmversion}-%{specrelease}.el7
 
 # What parts do we want to build?  We must build at least one kernel.
 # These are the kernels that are built IF the architecture allows it.
@@ -411,7 +408,7 @@ BuildRequires: ncurses-devel
 %{!?cross_build:BuildRequires: vim-minimal}
 %endif
 
-#Source0: linux-%{rpmversion}-%{pkgrelease}.el7.tar.xz
+#Source0: linux-%{rpmversion}-%{specrelease}.el7.tar.xz
 Source0: kernel-0.tar.gz
 
 Source11: x509.genkey
@@ -1399,8 +1396,8 @@ make DESTDIR=$RPM_BUILD_ROOT bootwrapper_install WRAPPER_OBJDIR=%{_libdir}/kerne
 
 %if %{with_doc}
 # Red Hat UEFI Secure Boot CA cert, which can be used to authenticate the kernel
-mkdir -p $RPM_BUILD_ROOT%{_datadir}/doc/kernel-keys/%{rpmversion}-%{pkgrelease}
-install -m 0644 %{SOURCE13} $RPM_BUILD_ROOT%{_datadir}/doc/kernel-keys/%{rpmversion}-%{pkgrelease}/kernel-signing-ca.cer
+mkdir -p $RPM_BUILD_ROOT%{_datadir}/doc/kernel-keys/%{rpmversion}-%{specrelease}
+install -m 0644 %{SOURCE13} $RPM_BUILD_ROOT%{_datadir}/doc/kernel-keys/%{rpmversion}-%{specrelease}/kernel-signing-ca.cer
 %endif
 
 # IBM: touch these for arches that don't build kernel-tools so source is consistent.
@@ -1555,8 +1552,8 @@ fi
 %dir %{_datadir}/doc/kernel-doc-%{rpmversion}/Documentation
 %dir %{_datadir}/doc/kernel-doc-%{rpmversion}
 %{_datadir}/man/man9/*
-%{_datadir}/doc/kernel-keys/%{rpmversion}-%{pkgrelease}/kernel-signing-ca.cer
-%dir %{_datadir}/doc/kernel-keys/%{rpmversion}-%{pkgrelease}
+%{_datadir}/doc/kernel-keys/%{rpmversion}-%{specrelease}/kernel-signing-ca.cer
+%dir %{_datadir}/doc/kernel-keys/%{rpmversion}-%{specrelease}
 %dir %{_datadir}/doc/kernel-keys
 %endif
 

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -24,9 +24,9 @@ Summary: The Linux kernel
 %define pkgrelease 1
 
 # allow pkg_release to have configurable %{?dist} tag
-%define specrelease 2%{?dist}
+%define specrelease 2
 
-%define pkg_release %{specrelease}
+%define pkg_release %{specrelease}%{?dist}
 
 # The kernel tarball/base version
 #define rheltarball %{rpmversion}-%{pkgrelease}.el7

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -24,10 +24,9 @@ Summary: The Linux kernel
 
 # This crazy release structure is so the daily scratch builds and the weekly official builds
 #   will always yum install correctly over each other
-%define release_week 32
 %define release_day 0
 %define release_spin 0
-%define release_date .%{?release_week}0%{?release_day}.%{?release_spin}
+%define release_date .0%{?release_day}.%{?release_spin}
 
 %define rpmversion 4.8.1
 %define pkgrelease 1
@@ -422,7 +421,7 @@ BuildRequires: ncurses-devel
 %endif
 
 #Source0: linux-%{rpmversion}-%{pkgrelease}.el7.tar.xz
-Source0: kernel-%{?release_week}0%{?release_day}.%{?release_spin}.tar.gz
+Source0: kernel-0%{?release_day}.%{?release_spin}.tar.gz
 
 Source11: x509.genkey
 
@@ -723,7 +722,7 @@ exit 1
 %endif
 
 tar xzf %{SOURCE0}
-mv kernel-%{?release_week}0%{?release_day}.%{?release_spin} kernel-%{KVRA}
+mv kernel-0%{?release_day}.%{?release_spin} kernel-%{KVRA}
 #setup -q -n kernel-%{rheltarball} -c
 
 

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -348,7 +348,7 @@ Group: System Environment/Kernel
 License: GPLv2
 URL: http://www.kernel.org/
 Version: %{rpmversion}
-Release: %{pkg_release}.1
+Release: %{pkg_release}
 # DO NOT CHANGE THE 'ExclusiveArch' LINE TO TEMPORARILY EXCLUDE AN ARCHITECTURE BUILD.
 # SET %%nobuildarches (ABOVE) INSTEAD
 ExclusiveArch: noarch i686 x86_64 ppc ppc64 ppc64le s390 s390x %{arm} ppcnf ppc476

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -24,9 +24,8 @@ Summary: The Linux kernel
 
 # This crazy release structure is so the daily scratch builds and the weekly official builds
 #   will always yum install correctly over each other
-%define release_day 0
 %define release_spin 0
-%define release_date .0%{?release_day}.%{?release_spin}
+%define release_date .0.%{?release_spin}
 
 %define rpmversion 4.8.1
 %define pkgrelease 1
@@ -421,7 +420,7 @@ BuildRequires: ncurses-devel
 %endif
 
 #Source0: linux-%{rpmversion}-%{pkgrelease}.el7.tar.xz
-Source0: kernel-0%{?release_day}.%{?release_spin}.tar.gz
+Source0: kernel-0.%{?release_spin}.tar.gz
 
 Source11: x509.genkey
 
@@ -722,7 +721,7 @@ exit 1
 %endif
 
 tar xzf %{SOURCE0}
-mv kernel-0%{?release_day}.%{?release_spin} kernel-%{KVRA}
+mv kernel-0.%{?release_spin} kernel-%{KVRA}
 #setup -q -n kernel-%{rheltarball} -c
 
 

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -21,7 +21,7 @@ Summary: The Linux kernel
 %global released_kernel 1
 
 %define rpmversion 4.8.1
-%define specrelease 2
+%define specrelease 3
 
 %define pkg_release %{specrelease}%{?dist}
 
@@ -1697,6 +1697,10 @@ fi
 
 
 %changelog
+* Fri Oct 14 2016 Murilo Opsfelder Araújo <muriloo@linux.vnet.ibm.com> - 4.8.1-3
+- Remove unused macros and simplify package numbering
+- Bump specrelease
+
 * Thu Oct 13 2016 Murilo Opsfelder Araújo <muriloo@linux.vnet.ibm.com> - 4.8.1-2
 - Fix kernel version to 4.8.1
 

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -22,10 +22,6 @@ Summary: The Linux kernel
 # For internal testing builds during development, it should be 0.
 %global released_kernel 1
 
-# This crazy release structure is so the daily scratch builds and the weekly official builds
-#   will always yum install correctly over each other
-%define release_date .0
-
 %define rpmversion 4.8.1
 %define pkgrelease 1
 
@@ -33,7 +29,7 @@ Summary: The Linux kernel
 %define specrelease 2%{?dist}
 
 #define ibm_release %{?repo}.1
-%define pkg_release %{specrelease}%{?buildid}%{?ibm_release}%{?release_date}
+%define pkg_release %{specrelease}%{?buildid}%{?ibm_release}
 
 # The kernel tarball/base version
 #define rheltarball %{rpmversion}-%{pkgrelease}.el7

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -28,8 +28,7 @@ Summary: The Linux kernel
 # allow pkg_release to have configurable %{?dist} tag
 %define specrelease 2%{?dist}
 
-#define ibm_release %{?repo}.1
-%define pkg_release %{specrelease}%{?buildid}%{?ibm_release}
+%define pkg_release %{specrelease}%{?buildid}
 
 # The kernel tarball/base version
 #define rheltarball %{rpmversion}-%{pkgrelease}.el7

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -24,8 +24,7 @@ Summary: The Linux kernel
 
 # This crazy release structure is so the daily scratch builds and the weekly official builds
 #   will always yum install correctly over each other
-%define release_spin 0
-%define release_date .0.%{?release_spin}
+%define release_date .0
 
 %define rpmversion 4.8.1
 %define pkgrelease 1
@@ -420,7 +419,7 @@ BuildRequires: ncurses-devel
 %endif
 
 #Source0: linux-%{rpmversion}-%{pkgrelease}.el7.tar.xz
-Source0: kernel-0.%{?release_spin}.tar.gz
+Source0: kernel-0.tar.gz
 
 Source11: x509.genkey
 
@@ -721,7 +720,7 @@ exit 1
 %endif
 
 tar xzf %{SOURCE0}
-mv kernel-0.%{?release_spin} kernel-%{KVRA}
+mv kernel-0 kernel-%{KVRA}
 #setup -q -n kernel-%{rheltarball} -c
 
 

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -408,8 +408,7 @@ BuildRequires: ncurses-devel
 %{!?cross_build:BuildRequires: vim-minimal}
 %endif
 
-#Source0: linux-%{rpmversion}-%{specrelease}.el7.tar.xz
-Source0: kernel.tar.gz
+Source0: linux-source.tar.gz
 
 Source11: x509.genkey
 
@@ -710,7 +709,7 @@ exit 1
 %endif
 
 tar xzf %{SOURCE0}
-mv kernel kernel-%{KVRA}
+mv linux-source kernel-%{KVRA}
 #setup -q -n kernel-%{rheltarball} -c
 
 

--- a/kernel/centOS/7.2/kernel.spec
+++ b/kernel/centOS/7.2/kernel.spec
@@ -16,8 +16,6 @@
 
 Summary: The Linux kernel
 
-# % define buildid .local
-
 # For a kernel released for public testing, released_kernel should be 1.
 # For internal testing builds during development, it should be 0.
 %global released_kernel 1
@@ -28,7 +26,7 @@ Summary: The Linux kernel
 # allow pkg_release to have configurable %{?dist} tag
 %define specrelease 2%{?dist}
 
-%define pkg_release %{specrelease}%{?buildid}
+%define pkg_release %{specrelease}
 
 # The kernel tarball/base version
 #define rheltarball %{rpmversion}-%{pkgrelease}.el7

--- a/kernel/kernel.yaml
+++ b/kernel/kernel.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/linux.git'
  branch: 'hostos-devel'
  commit_id: 'a3a03f3'
- expects_source: "kernel-0.0"
+ expects_source: "kernel-0"
  files:
   centos:
    '7.2':

--- a/kernel/kernel.yaml
+++ b/kernel/kernel.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/linux.git'
  branch: 'hostos-devel'
  commit_id: 'a3a03f3'
- expects_source: "kernel-00.0"
+ expects_source: "kernel-0.0"
  files:
   centos:
    '7.2':

--- a/kernel/kernel.yaml
+++ b/kernel/kernel.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/linux.git'
  branch: 'hostos-devel'
  commit_id: 'a3a03f3'
- expects_source: "kernel-3200.0"
+ expects_source: "kernel-00.0"
  files:
   centos:
    '7.2':

--- a/kernel/kernel.yaml
+++ b/kernel/kernel.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/linux.git'
  branch: 'hostos-devel'
  commit_id: 'a3a03f3'
- expects_source: "kernel"
+ expects_source: "linux-source"
  files:
   centos:
    '7.2':

--- a/kernel/kernel.yaml
+++ b/kernel/kernel.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/linux.git'
  branch: 'hostos-devel'
  commit_id: 'a3a03f3'
- expects_source: "kernel-0"
+ expects_source: "kernel"
  files:
   centos:
    '7.2':


### PR DESCRIPTION
* c96cdd2 Update kernel package to 4.8.1-3
* 91c5d11 Rename Source0 to linux-source.tar.gz
* bbf9cb2 Remove trailing -0 from Source0 in kernel.spec
* 13702cb Remove trailing .1 from Release macro in kernel.spec
* 6343965 Replace pkgrelease by specrelease in kernel.spec
* 6077452 Move dist to specrelease in kernel.spec
* 3b25c01 Remove buildid from kernel.spec
* b0e87bf Remove ibm_release from kernel.spec
* 8c19155 Remove release_date from kernel.spec
* 805bc6c Remove release_spin from kernel.spec
* a358f02 Remove release_day from kernel.spec
* a6ade38 Remove release_week from kernel.spec
