### PR TITLE
Use hostos-devel branch in sos

### DIFF
--- a/sos/sos.yaml
+++ b/sos/sos.yaml
@@ -1,7 +1,7 @@
 Package:
  name: 'sos'
  clone_url: 'https://github.com/open-power-host-os/sos.git'
- branch: 'powerkvm-v3.1.1'
+ branch: 'hostos-devel'
  commit_id: '52dd1db'
  expects_source: "sos"
  files:


### PR DESCRIPTION
It was powerkvm-v3.1.1 but now it's hostos-devel, even though they're have the
same HEAD right now.