### PR TITLE
Simplify libvirt release numbering

### DIFF
--- a/libvirt/centOS/7.2/libvirt.spec
+++ b/libvirt/centOS/7.2/libvirt.spec
@@ -382,12 +382,11 @@ Version: 2.2.0
 #define ibm_release %{?repo}.1
 # This release structure is so the daily scratch builds and the weekly official builds
 #   will always yum install correctly over each other
-%define release_day 0
 %define release_spin 0
-%define release_date .0%{?release_day}.%{?release_spin}
+%define release_date .0.%{?release_spin}
 Release: 5%{?dist}%{?ibm_release}%{?release_date}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
-Source0: libvirt-0%{?release_day}.%{?release_spin}.tar.gz
+Source0: libvirt-0.%{?release_spin}.tar.gz
 License: LGPLv2+
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -1238,7 +1237,7 @@ Libvirt plugin for NSS for translating domain names into IP addresses.
 %endif
 
 %prep
-%setup -n %{name}-0%{?release_day}.%{?release_spin}
+%setup -n %{name}-0.%{?release_spin}
 
 # Patches have to be stored in a temporary file because RPM has
 # a limit on the length of the result of any macro expansion;

--- a/libvirt/centOS/7.2/libvirt.spec
+++ b/libvirt/centOS/7.2/libvirt.spec
@@ -379,10 +379,7 @@
 Summary: Library providing a simple virtualization API
 Name: libvirt
 Version: 2.2.0
-#define ibm_release %{?repo}.1
-# This release structure is so the daily scratch builds and the weekly official builds
-#   will always yum install correctly over each other
-Release: 5%{?dist}%{?ibm_release}
+Release: 5%{?dist}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
 Source0: libvirt-0.tar.gz
 License: LGPLv2+

--- a/libvirt/centOS/7.2/libvirt.spec
+++ b/libvirt/centOS/7.2/libvirt.spec
@@ -381,7 +381,7 @@ Name: libvirt
 Version: 2.2.0
 Release: 5%{?dist}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
-Source0: libvirt-0.tar.gz
+Source0: libvirt.tar.gz
 License: LGPLv2+
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -1232,7 +1232,7 @@ Libvirt plugin for NSS for translating domain names into IP addresses.
 %endif
 
 %prep
-%setup -n %{name}-0
+%setup -n libvirt
 
 # Patches have to be stored in a temporary file because RPM has
 # a limit on the length of the result of any macro expansion;

--- a/libvirt/centOS/7.2/libvirt.spec
+++ b/libvirt/centOS/7.2/libvirt.spec
@@ -382,11 +382,10 @@ Version: 2.2.0
 #define ibm_release %{?repo}.1
 # This release structure is so the daily scratch builds and the weekly official builds
 #   will always yum install correctly over each other
-%define release_spin 0
-%define release_date .0.%{?release_spin}
+%define release_date .0
 Release: 5%{?dist}%{?ibm_release}%{?release_date}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
-Source0: libvirt-0.%{?release_spin}.tar.gz
+Source0: libvirt-0.tar.gz
 License: LGPLv2+
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -1237,7 +1236,7 @@ Libvirt plugin for NSS for translating domain names into IP addresses.
 %endif
 
 %prep
-%setup -n %{name}-0.%{?release_spin}
+%setup -n %{name}-0
 
 # Patches have to be stored in a temporary file because RPM has
 # a limit on the length of the result of any macro expansion;

--- a/libvirt/centOS/7.2/libvirt.spec
+++ b/libvirt/centOS/7.2/libvirt.spec
@@ -382,8 +382,7 @@ Version: 2.2.0
 #define ibm_release %{?repo}.1
 # This release structure is so the daily scratch builds and the weekly official builds
 #   will always yum install correctly over each other
-%define release_date .0
-Release: 5%{?dist}%{?ibm_release}%{?release_date}
+Release: 5%{?dist}%{?ibm_release}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
 Source0: libvirt-0.tar.gz
 License: LGPLv2+

--- a/libvirt/centOS/7.2/libvirt.spec
+++ b/libvirt/centOS/7.2/libvirt.spec
@@ -379,7 +379,7 @@
 Summary: Library providing a simple virtualization API
 Name: libvirt
 Version: 2.2.0
-Release: 5%{?dist}
+Release: 6%{?dist}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
 Source0: libvirt.tar.gz
 License: LGPLv2+
@@ -2425,6 +2425,10 @@ exit 0
 #doc examples/systemtap
 
 %changelog
+* Wed Oct 19 2016 Murilo Opsfelder Araújo <muriloo@linux.vnet.ibm.com> - 2.2.0-6
+- Remove unused macros and simplify package numbering
+- Bump release
+
 * Wed Oct 05 2016 user - 2.2.0-5.3200.0
 - ddccbf6 qemu: Fix coldplug of vcpus
 98fe4f8 qemu: process: Enforce vcpu order range to <1,maxvcpus>

--- a/libvirt/centOS/7.2/libvirt.spec
+++ b/libvirt/centOS/7.2/libvirt.spec
@@ -382,13 +382,12 @@ Version: 2.2.0
 #define ibm_release %{?repo}.1
 # This release structure is so the daily scratch builds and the weekly official builds
 #   will always yum install correctly over each other
-%define release_week 32
 %define release_day 0
 %define release_spin 0
-%define release_date .%{?release_week}0%{?release_day}.%{?release_spin}
+%define release_date .0%{?release_day}.%{?release_spin}
 Release: 5%{?dist}%{?ibm_release}%{?release_date}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
-Source0: libvirt-%{?release_week}0%{?release_day}.%{?release_spin}.tar.gz
+Source0: libvirt-0%{?release_day}.%{?release_spin}.tar.gz
 License: LGPLv2+
 Group: Development/Libraries
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
@@ -1239,7 +1238,7 @@ Libvirt plugin for NSS for translating domain names into IP addresses.
 %endif
 
 %prep
-%setup -n %{name}-%{?release_week}0%{?release_day}.%{?release_spin}
+%setup -n %{name}-0%{?release_day}.%{?release_spin}
 
 # Patches have to be stored in a temporary file because RPM has
 # a limit on the length of the result of any macro expansion;

--- a/libvirt/libvirt.yaml
+++ b/libvirt/libvirt.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/libvirt.git'
  branch: 'hostos-devel'
  commit_id: 'ddccbf6'
- expects_source: "libvirt-00.0"
+ expects_source: "libvirt-0.0"
  files:
   centos:
    '7.2':

--- a/libvirt/libvirt.yaml
+++ b/libvirt/libvirt.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/libvirt.git'
  branch: 'hostos-devel'
  commit_id: 'ddccbf6'
- expects_source: "libvirt-0"
+ expects_source: "libvirt"
  files:
   centos:
    '7.2':

--- a/libvirt/libvirt.yaml
+++ b/libvirt/libvirt.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/libvirt.git'
  branch: 'hostos-devel'
  commit_id: 'ddccbf6'
- expects_source: "libvirt-0.0"
+ expects_source: "libvirt-0"
  files:
   centos:
    '7.2':

--- a/libvirt/libvirt.yaml
+++ b/libvirt/libvirt.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/libvirt.git'
  branch: 'hostos-devel'
  commit_id: 'ddccbf6'
- expects_source: "libvirt-3200.0"
+ expects_source: "libvirt-00.0"
  files:
   centos:
    '7.2':


### PR DESCRIPTION
- 54accdc Update libvirt package to 2.2.0-6
- 4b455d7 Rename Source0 to libvirt.tar.gz in libvirt.spec
- a213c4f Remove ibm_release from libvirt.spec
- a12ad8e Remove release_date from libvirt.spec
- 5da1061 Remove release_spin from libvirt.spec
- 89f8ea7 Remove release_day from libvirt.spec
- 6f672f6 Remove release_week from libvirt.spec
