### PR TITLE
Use branch hostos-devel for kimchi/ginger/wok family

### DIFF
--- a/ginger/centOS/7.2/ginger.spec
+++ b/ginger/centOS/7.2/ginger.spec
@@ -1,6 +1,6 @@
 Name:       ginger
 Version:    2.3.0
-Release:    4%{?dist}
+Release:    5%{?dist}
 Summary:    Host management plugin for Wok - Webserver Originated from Kimchi
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 Group:      System Environment/Base
@@ -120,6 +120,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Nov 09 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.3.0-5
+- Ginger rebase
+
 * Thu Nov 3 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> 2.3.0-4
 - Spec cleanup
 

--- a/ginger/ginger.yaml
+++ b/ginger/ginger.yaml
@@ -1,8 +1,8 @@
 Package:
  name: 'ginger'
  clone_url: 'https://github.com/open-power-host-os/ginger.git'
- branch: 'powerkvm-v3.1.1'
- commit_id: 'f9164a4'
+ branch: 'hostos-devel'
+ commit_id: 'fd044e5'
  expects_source: 'ginger'
  files:
   centos:

--- a/gingerbase/centOS/7.2/gingerbase.spec
+++ b/gingerbase/centOS/7.2/gingerbase.spec
@@ -4,7 +4,7 @@
 
 Name:       ginger-base
 Version:    2.2.1
-Release:    4%{?dist}
+Release:    5%{?dist}
 Summary:    Wok plugin for base host management
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch
@@ -74,6 +74,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Nov 09 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.2.1-5
+- ginger-base rebase
+
 * Thu Nov 3 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.2.1-4
 - spec cleanup
 

--- a/gingerbase/gingerbase.yaml
+++ b/gingerbase/gingerbase.yaml
@@ -1,8 +1,8 @@
 Package:
  name: 'gingerbase'
  clone_url: 'https://github.com/open-power-host-os/gingerbase.git'
- branch: 'powerkvm-v3.1.1'
- commit_id: '56913b3'
+ branch: 'hostos-devel'
+ commit_id: '8296bfa'
  expects_source: 'ginger-base'
  files:
   centos:

--- a/kimchi/centOS/7.2/kimchi.spec
+++ b/kimchi/centOS/7.2/kimchi.spec
@@ -1,6 +1,6 @@
 Name:       kimchi
 Version:    2.3.0
-Release:    4%{?dist}
+Release:    5%{?dist}
 Summary:    Kimchi server application
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch
@@ -90,6 +90,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Nov 09 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.3.0-5
+- Kimchi rebase
+
 * Thu Nov 3 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.3.0-4
 - spec cleanup
 

--- a/kimchi/kimchi.yaml
+++ b/kimchi/kimchi.yaml
@@ -1,8 +1,8 @@
 Package:
  name: 'kimchi'
  clone_url: 'https://github.com/open-power-host-os/kimchi.git'
- branch: 'powerkvm-v3.1.1'
- commit_id: '71787ff'
+ branch: 'hostos-devel'
+ commit_id: 'f4934ca'
  expects_source: 'kimchi'
  files:
   centos:

--- a/wok/centOS/7.2/wok.spec
+++ b/wok/centOS/7.2/wok.spec
@@ -1,6 +1,6 @@
 Name:       wok
 Version:    2.3.0
-Release:    4%{?dist}
+Release:    5%{?dist}
 Summary:    Wok - Webserver Originated from Kimchi
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch
@@ -174,6 +174,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Wed Nov 09 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.3.0-5
+- wok rebase
+
 * Thu Nov 3 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 2.3.0-4
 - Spec cleanup
 

--- a/wok/wok.yaml
+++ b/wok/wok.yaml
@@ -1,8 +1,8 @@
 Package:
  name: 'wok'
  clone_url: 'https://github.com/open-power-host-os/wok.git'
- branch: 'powerkvm-v3.1.1'
- commit_id: '5443d11'
+ branch: 'hostos-devel'
+ commit_id: '8d8db13'
  expects_source: 'wok'
  files:
   centos:


### PR DESCRIPTION
Changed from powerkvm-v3.1.1 to hostos-devel branches and also updated the
commit ids, as the follow:

- ginger  from 'f9164a4' to 'fd044e5'
- gingerbase from '56913b3' to '8296bfa'
- kimchi from '71787ff' to 'f4934ca'
- wok from '5443d11' to '8d8db13'

According to comment
https://github.com/open-power-host-os/builds/issues/106#issuecomment-259210354