### PR TITLE
Use full SHA-1 for commit IDs in YAML files

### DIFF
--- a/SLOF/SLOF.yaml
+++ b/SLOF/SLOF.yaml
@@ -3,7 +3,7 @@ Package:
  clone_url: 'https://github.com/open-power-host-os/slof.git'
  branch: 'powerkvm-v3.1.1'
  # this is tag qemu-slof-20160525 but since nobody else uses tags let's keep it as a commit id
- commit_id: 'b2d56f3'
+ commit_id: 'b2d56f3a322f2c6375a87d11274fbae1cde66ae8'
  expects_source: "SLOF"
  files:
   centos:

--- a/build_dependencies/golang/golang.yaml
+++ b/build_dependencies/golang/golang.yaml
@@ -1,7 +1,7 @@
 Package:
  name: 'golang'
  clone_url: 'https://github.com/golang/go.git'
- commit_id: 'b67902f'
+ commit_id: 'b67902fee7b56dd3235b2f489550c279248bacb9'
  branch: 'release-branch.go1.7'
  expects_source: 'go'
  files:

--- a/build_dependencies/librtas/librtas.yaml
+++ b/build_dependencies/librtas/librtas.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'librtas'
  clone_url: 'https://github.com/nfont/librtas.git'
  branch: 'master'
- commit_id: '3fe4911'
+ commit_id: '3fe4911fa9e456e6cae2f314cff46894025b7fb9'
  expects_source: "librtas-1.4.1"
  files:
   centos:

--- a/crash/crash.yaml
+++ b/crash/crash.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'crash'
  clone_url: 'https://github.com/crash-utility/crash.git'
  branch: 'master'
- commit_id: '64531dc' # 7.1.6
+ commit_id: '64531dc850f2840cedafa143fe051d2cfeae5247' # 7.1.6
  version:
    file: '.rh_rpm_package'
    regex: '([\w.-]+)'

--- a/dependencies/libseccomp/libseccomp.yaml
+++ b/dependencies/libseccomp/libseccomp.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'libseccomp'
  clone_url: 'https://github.com/seccomp/libseccomp.git'
  branch: 'release-2.3'
- commit_id: 'eedd26d'
+ commit_id: 'eedd26dc59641878dabd771e2ff15e729a85ac69'
  expects_source: "libseccomp-2.3.1"
  files:
   centos:

--- a/dependencies/libservicelog/libservicelog.yaml
+++ b/dependencies/libservicelog/libservicelog.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'libservicelog'
  clone_url: 'https://github.com/open-power-host-os/libservicelog.git'
  branch: 'hostos-devel'
- commit_id: 'b5ebd51'
+ commit_id: 'b5ebd51d01245a7bff961f30ca9db794629b0f8a'
  expects_source: "libservicelog"
  files:
   centos:

--- a/dependencies/libvpd/libvpd.yaml
+++ b/dependencies/libvpd/libvpd.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'libvpd'
  clone_url: 'https://github.com/open-power-host-os/libvpd.git'
  branch: 'master'
- commit_id: 'cf5d293'
+ commit_id: 'cf5d29342e449032d6c7d1f4f8b7516052a2210b'
  expects_source: "libvpd"
  files:
   centos:

--- a/ginger/ginger.yaml
+++ b/ginger/ginger.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'ginger'
  clone_url: 'https://github.com/open-power-host-os/ginger.git'
  branch: 'hostos-devel'
- commit_id: 'fd044e5'
+ commit_id: 'fd044e599d16a1120102aa1bca17a314833b4400'
  expects_source: 'ginger'
  files:
   centos:

--- a/gingerbase/gingerbase.yaml
+++ b/gingerbase/gingerbase.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'gingerbase'
  clone_url: 'https://github.com/open-power-host-os/gingerbase.git'
  branch: 'hostos-devel'
- commit_id: '8296bfa'
+ commit_id: '8296bfafd142fe2486f9d4935f098584cdd1b6a1'
  expects_source: 'ginger-base'
  files:
   centos:

--- a/kernel/kernel.yaml
+++ b/kernel/kernel.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'kernel'
  clone_url: 'https://github.com/open-power-host-os/linux.git'
  branch: 'hostos-devel'
- commit_id: 'ce1fd2c'
+ commit_id: 'ce1fd2ce4490b17d8d34db47ca8e125e139b93d3'
  version:
    file: 'Makefile'
    regex: 'VERSION.*([\d.]+)\nPATCHLEVEL\s*=\s*(?P<patch>[\d.]*)\nSUBLEVEL\s*=\s*(?(patch)([\d.]*))'

--- a/kimchi/kimchi.yaml
+++ b/kimchi/kimchi.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'kimchi'
  clone_url: 'https://github.com/open-power-host-os/kimchi.git'
  branch: 'hostos-devel'
- commit_id: 'f4934ca'
+ commit_id: 'f4934ca08d45760a16b4e39ebb2ee3704f64b445'
  expects_source: 'kimchi'
  files:
   centos:

--- a/libvirt/libvirt.yaml
+++ b/libvirt/libvirt.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'libvirt'
  clone_url: 'https://github.com/open-power-host-os/libvirt.git'
  branch: 'hostos-devel'
- commit_id: 'ddccbf6'
+ commit_id: 'ddccbf6072a3f95e053cc9934d1178cb1acd2aa7'
  expects_source: "libvirt"
  version:
    file: 'configure.ac'

--- a/linux-firmware/linux-firmware.yaml
+++ b/linux-firmware/linux-firmware.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'linux-firmware'
  clone_url: 'https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git'
  branch: 'master'
- commit_id: '70a3c2a'
+ commit_id: '70a3c2adcce7c51e4f26e929d666237904f6fd31'
  expects_source: "linux-firmware"
  files:
   centos:

--- a/lsvpd/lsvpd.yaml
+++ b/lsvpd/lsvpd.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'lsvpd'
  clone_url: 'https://github.com/open-power-host-os/lsvpd.git'
  branch: 'master'
- commit_id: '22bf310'
+ commit_id: '22bf31003c097d993e73d22e745c36d16b5f85a2'
  expects_source: "lsvpd"
  files:
   centos:

--- a/noVNC/noVNC.yaml
+++ b/noVNC/noVNC.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'noVNC'
  clone_url: 'https://github.com/kanaka/noVNC.git'
  branch: 'master' #v0.5.1
- commit_id: 'fc00821'
+ commit_id: 'fc00821eba469641c6c94706726c3d78e46460a2'
  expects_source: 'novnc'
  files:
   centos:

--- a/powerpc-utils/powerpc-utils.yaml
+++ b/powerpc-utils/powerpc-utils.yaml
@@ -1,7 +1,7 @@
 Package:
  name: 'powerpc-utils'
  clone_url: 'https://github.com/nfont/powerpc-utils.git'
- commit_id: '6805ab4' #1.3.2
+ commit_id: '6805ab4b46419321995459734f48dfcba08eec35' #1.3.2
  branch: 'master'
  expects_source: "powerpc-utils"
  files:

--- a/ppc64-diag/ppc64-diag.yaml
+++ b/ppc64-diag/ppc64-diag.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'ppc64-diag'
  clone_url: 'https://github.com/open-power-host-os/ppc64-diag.git'
  branch: 'master'
- commit_id: '92ea7c8'
+ commit_id: '92ea7c82a54f4c1d1fe25677f205ebca781e53c3'
  expects_source: "ppc64-diag-2.7.1"
  files:
   centos:

--- a/qemu/qemu.yaml
+++ b/qemu/qemu.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'qemu'
  clone_url: 'https://github.com/open-power-host-os/qemu.git'
  branch: 'hostos-devel'
- commit_id: 'afb0d80'
+ commit_id: 'afb0d801d4a670f0f03daea0d410753d7bc06bac'
  expects_source: "qemu"
  files:
   centos:

--- a/servicelog/servicelog.yaml
+++ b/servicelog/servicelog.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'servicelog'
  clone_url: 'https://github.com/open-power-host-os/servicelog.git'
  branch: 'hostos-devel'
- commit_id: '7d33cd3'
+ commit_id: '7d33cd33507d6f11fb86c4bc13d752cb122759f7'
  expects_source: "servicelog"
  files:
   centos:

--- a/sos/sos.yaml
+++ b/sos/sos.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'sos'
  clone_url: 'https://github.com/open-power-host-os/sos.git'
  branch: 'hostos-devel'
- commit_id: '52dd1db'
+ commit_id: '52dd1dbc52783e622ca0a96e3e9c182bb26887fe'
  expects_source: "sos"
  files:
   centos:

--- a/systemtap/systemtap.yaml
+++ b/systemtap/systemtap.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'systemtap'
  clone_url: 'git://sourceware.org/git/systemtap.git'
  branch: 'master'
- commit_id: '616ec7a' # release-3.0
+ commit_id: '616ec7a0b916df7785d911b824c3df6eb022b213' # release-3.0
  expects_source: "systemtap-3.0"
  files:
   centos:

--- a/wok/wok.yaml
+++ b/wok/wok.yaml
@@ -2,7 +2,7 @@ Package:
  name: 'wok'
  clone_url: 'https://github.com/open-power-host-os/wok.git'
  branch: 'hostos-devel'
- commit_id: '8d8db13'
+ commit_id: '8d8db1384e01224de28944330da5541bd99ac3f0'
  expects_source: 'wok'
  files:
   centos:


### PR DESCRIPTION
Some projects (e.g. kernel) might require more than 7 digits to identify
a commit SHA-1 uniquely.
This also makes all packages use the same format.