### PR TITLE
Add docker-swarm package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,8 @@ docker            			1.1.2
 gcc			                4.8.5
 oci-register-machine	  0-1.8
 oci-systemd-hook	      0-1.8
-
 golang			            1.7.1
 crash			              7.1.6
 flannel                 0.5.5
+docker-swarm            1.1.0
 ======================  =======

--- a/docker-swarm/centOS/7.2/docker-swarm.spec
+++ b/docker-swarm/centOS/7.2/docker-swarm.spec
@@ -1,0 +1,52 @@
+#
+# spec file for package docker-swarm
+#
+# Copyright (c) 2015 SUSE LINUX Products GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+
+Name:           docker-swarm
+Version:        1.1.0
+Release:        1
+Summary:        Docker-native clustering system
+License:        Apache-2.0
+Group:          System/Management
+Url:            https://github.com/docker/swarm
+Source:         %{name}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildRequires:  go >= 1.5
+
+%description
+Docker Swarm is native clustering for Docker. It turns a pool of Docker hosts
+into a single, virtual host.
+
+%prep
+%setup -q -n %{name}
+
+%build
+export GOPATH=$PWD/Godeps/_workspace
+mkdir -p $GOPATH/src/github.com/docker
+ln -s $PWD $GOPATH/src/github.com/docker/swarm
+go build -x -o swarm
+
+%install
+%{__mkdir_p} %{buildroot}%{_bindir}
+%{__install} -m755 swarm %{buildroot}%{_bindir}/swarm
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/swarm
+%doc LICENSE.docs README.md
+
+%changelog

--- a/docker-swarm/centOS/7.2/rpmmacro
+++ b/docker-swarm/centOS/7.2/rpmmacro
@@ -1,0 +1,1 @@
+%define debug_package %{nil}

--- a/docker-swarm/docker-swarm.yaml
+++ b/docker-swarm/docker-swarm.yaml
@@ -1,0 +1,11 @@
+Package:
+ name: 'docker-swarm'
+ clone_url: 'https://github.com/docker/swarm.git'
+ branch: 'master'
+ commit_id: 'a0fd82b90932741bda54245e990df433a9ee06a7'
+ expects_source: 'docker-swarm'
+ files:
+  centos:
+   '7.2':
+    spec: 'centOS/7.2/docker-swarm.spec'
+    rpmmacro: 'centOS/7.2/rpmmacro'


### PR DESCRIPTION
Debug info RPM is not being built.

Spec file based on openSUSE:
https://build.opensuse.org/package/view_file/Virtualization:containers/docker-swarm/docker-swarm.spec