### PR TITLE
Fix docker-swarm build

### DIFF
--- a/docker-swarm/centOS/7.2/rpmmacro
+++ b/docker-swarm/centOS/7.2/rpmmacro
@@ -1,1 +1,1 @@
-%define debug_package %{nil}
+%debug_package %{nil}


### PR DESCRIPTION
I made a mistake in PR #56 and used the wrong syntax in the rpmmacro file:
%define debug_package %{nil}

the correct doesn't use define piece (which is used hardcoded in the spec for
instance):
%debug_package %{nil}