### PR TITLE
Add lshw package

### DIFF
--- a/lshw/centOS/7.2/SOURCES/lshw-gui
+++ b/lshw/centOS/7.2/SOURCES/lshw-gui
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+/usr/bin/pkexec /usr/sbin/gtk-lshw
+
+

--- a/lshw/centOS/7.2/SOURCES/lshw.desktop
+++ b/lshw/centOS/7.2/SOURCES/lshw.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Hardware Lister
+Comment=Browse hardware on host computer
+StartupNotify=true
+Exec=/usr/bin/lshw-gui
+Icon=lshw-logo
+Terminal=false
+Type=Application
+Categories=GTK;System;

--- a/lshw/centOS/7.2/SOURCES/org.ezix.lshw.gui.policy
+++ b/lshw/centOS/7.2/SOURCES/org.ezix.lshw.gui.policy
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+"-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+"http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+ <vendor>lshw</vendor>
+ <vendor_url>http://ezix.org/project/wiki/HardwareLiSter</vendor_url>
+ <action id="org.ezix.lshw.gui.pkexec.run">
+    <description>Hardware Lister (lshw) - list hardware information</description>
+    <message>Authentication is required to run lshw-gui</message>
+    <icon_name>lshw-logo</icon_name>
+    <defaults>
+     <allow_any>no</allow_any>
+     <allow_inactive>no</allow_inactive>
+     <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/sbin/gtk-lshw</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+ </action>
+</policyconfig>

--- a/lshw/centOS/7.2/lshw.spec
+++ b/lshw/centOS/7.2/lshw.spec
@@ -1,0 +1,115 @@
+# Conditional build (--with/--without option)
+#   --without gui
+
+Summary: HardWare LiSter
+Name: lshw
+Version: B.02.18
+Release: 1
+Source: %{name}.tar.gz
+URL: http://lshw.ezix.org/
+License: GPL
+Group: Applications/System
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+lshw (Hardware Lister) is a small tool to provide detailed informaton on
+the hardware configuration of the machine. It can report exact memory
+configuration, firmware version, mainboard configuration, CPU version
+and speed, cache configuration, bus speed, etc. on DMI-capable x86s
+systems and on some PowerPC machines (PowerMac G4 is known to work).
+
+Information can be output in plain text, XML or HTML.
+
+For detailed information on lshw features and usage, please see the
+included documentation or go to the lshw Web page,
+http://lshw.ezix.org/
+
+%if %{!?_without_gui:1}0
+%package gui
+Summary: HardWare LiSter (GUI version)
+Group: Applications/System
+Requires: %{name} >= %{version}
+Requires: gtk2 >= 2.4
+BuildRequires: gtk2-devel >= 2.4
+
+%description gui
+lshw (Hardware Lister) is a small tool to provide detailed informaton on
+the hardware configuration of the machine. It can report exact memory
+configuration, firmware version, mainboard configuration, CPU version
+and speed, cache configuration, bus speed, etc. on DMI-capable x86s
+ systems and on some PowerPC machines (PowerMac G4 is known to work).
+
+This package provides a graphical user interface to display hardware
+information.
+
+For detailed information on lshw features and usage, please see the
+included documentation or go to the lshw Web page,
+http://lshw.ezix.org/
+
+%endif
+
+%prep
+%setup -q -n %{name}
+
+%build
+%{__make} %{?_smp_mflags} \
+  PREFIX="%{_prefix}" \
+  SBINDIR="%{_sbindir}" \
+  MANDIR="%{_mandir}" \
+  DATADIR="%{_datadir}" \
+  all
+%if %{!?_without_gui:1}0
+%{__make} %{?_smp_mflags} \
+  PREFIX="%{_prefix}" \
+  SBINDIR="%{_sbindir}" \
+  MANDIR="%{_mandir}" \
+  DATADIR="%{_datadir}" \
+  gui
+%endif
+
+%install
+%{__rm} -rf "%{buildroot}"
+
+%{__make} \
+  DESTDIR="%{buildroot}" \
+  PREFIX="%{_prefix}" \
+  SBINDIR="%{_sbindir}" \
+  MANDIR="%{_mandir}" \
+  DATADIR="%{_datadir}" \
+  INSTALL="%{__install} -p" \
+  install
+%if %{!?_without_gui:1}0
+%{__make} \
+  DESTDIR="%{buildroot}" \
+  PREFIX="%{_prefix}" \
+  SBINDIR="%{_sbindir}" \
+  MANDIR="%{_mandir}" \
+  DATADIR="%{_datadir}" \
+  INSTALL="%{__install} -p" \
+  install-gui
+%endif
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%files
+%defattr(-,root,root, 0555)
+%doc README.md COPYING docs/TODO docs/Changelog docs/lshw.xsd
+%{_sbindir}/lshw
+%doc %{_mandir}/man?/*
+%{_datadir}/lshw/
+%{_datadir}/locale/*/*/*
+
+%if %{!?_without_gui:1}0
+%files gui
+%defattr(-,root,root, 0555)
+%doc COPYING
+%{_sbindir}/gtk-lshw
+%endif
+
+%changelog
+* Tue May  1 2007 Lyonel Vincent <lyonel@ezix.org> B.02.10-2
+- spec file cleanup
+
+* Thu Apr 10 2003 Lyonel Vincent <lyonel@ezix.org> A.01.00-1
+- RPM packaging

--- a/lshw/lshw.yaml
+++ b/lshw/lshw.yaml
@@ -1,0 +1,11 @@
+Package:
+ name: 'lshw'
+ clone_url: 'https://github.com/lyonel/lshw.git'
+ branch: 'master'
+ commit_id: 'f9bdcc342d525f8504b81a9a344d58f57aa9b5dc'
+ expects_source: 'lshw'
+ files:
+  centos:
+   '7.2':
+    spec: 'centOS/7.2/lshw.spec'
+    build_files: 'centOS/7.2/SOURCES'


### PR DESCRIPTION
This builds the upstream development branch (based on B.02.18) which:
- adds pseries guest information
- adds machine description for PowerNV and pseries LPAR platform
- fixes motherboard model reporting for Power systems
- fixes physical ID information for CPU nodes
- adds Vital Product Data information for FSP and BMC based Power
  systems
- updates CPU information for Power systems