### PR TITLE
Adjust ppc64-diag yaml and spec to be flexible to version changes

### DIFF
--- a/ppc64-diag/centOS/7.2/SOURCES/ppc64-diag-2.4.3-scriptlocation.patch
+++ b/ppc64-diag/centOS/7.2/SOURCES/ppc64-diag-2.4.3-scriptlocation.patch
@@ -8,14 +8,14 @@ diff -up ppc64-diag-2.6.7/scripts/Makefile.script_loc ppc64-diag-2.6.7/scripts/M
 -	@$(call install_files,$(SCRIPTS),744,$(DESTDIR)/etc/ppc64-diag)
 +	@$(call install_files,$(SCRIPTS),744,$(DESTDIR)/usr/libexec/ppc64-diag)
  	@$(call install_files,$(INIT_FILES),755,$(DESTDIR)/$(LIBEXEC_DIR))
- 	@$(call install_files,$(SERVICE_SCRIPT),755,$(DESTDIR)/$(SYSTEMD_DIR))
+ 	@$(call install_files,$(SERVICE_SCRIPT),644,$(DESTDIR)/$(SYSTEMD_DIR))
  	@$(call install_files,$(CFG_FILES),644,$(DESTDIR)/etc/ppc64-diag)
  
  uninstall: 
 -	@$(call uninstall_files,$(SCRIPTS),$(DESTDIR)/etc/ppc64-diag)
 +	@$(call uninstall_files,$(SCRIPTS),$(DESTDIR)/usr/libexec/ppc64-diag)
  	@$(call uninstall_files,$(INIT_FILES),$(DESTDIR)/$(LIBEXEC_DIR))
- 	@$(call uninstall_files,$(SERVICE_SCRIPT),755,$(DESTDIR)/$(SYSTEMD_DIR))
+ 	@$(call uninstall_files,$(SERVICE_SCRIPT),644,$(DESTDIR)/$(SYSTEMD_DIR))
  	@$(call uninstall_files,$(CFG_FILES),$(DESTDIR)/etc/ppc64-diag)
 diff -up ppc64-diag-2.6.7/scripts/ppc64_diag_mkrsrc.script_loc ppc64-diag-2.6.7/scripts/ppc64_diag_mkrsrc
 --- ppc64-diag-2.6.7/scripts/ppc64_diag_mkrsrc.script_loc	2014-08-16 07:35:55.000000000 +0200

--- a/ppc64-diag/centOS/7.2/ppc64-diag.spec
+++ b/ppc64-diag/centOS/7.2/ppc64-diag.spec
@@ -18,7 +18,7 @@ Requires:	librtas
 # License change
 Requires:	powerpc-utils >= 1.3.2
 
-Source0:        http://downloads.sourceforge.net/project/linux-diag/ppc64-diag/v%{version}/%{name}-%{version}.tar.gz
+Source0:        %{name}.tar.gz
 Source1:        rtas_errd.service
 Patch0:         ppc64-diag-2.4.2-messagecatalog-location.patch
 Patch1:         ppc64-diag-2.4.2-chkconfig.patch
@@ -47,7 +47,7 @@ administrators or connected service frameworks.
 %global __requires_exclude %{?__requires_exclude:%__requires_exclude|}\/usr\/libexec\/ppc64-diag\/servevent_parse.pl
 
 %prep
-%setup -q
+%setup -q -n %{name}
 %patch0 -p1 -b .msg_loc
 %patch1 -p1 -b .chkconfig
 %patch2 -p1 -b .script_loc

--- a/ppc64-diag/ppc64-diag.yaml
+++ b/ppc64-diag/ppc64-diag.yaml
@@ -2,8 +2,8 @@ Package:
  name: 'ppc64-diag'
  clone_url: 'https://github.com/open-power-host-os/ppc64-diag.git'
  branch: 'hostos-devel'
- commit_id: '92ea7c82a54f4c1d1fe25677f205ebca781e53c3'
- expects_source: "ppc64-diag-2.7.1"
+ commit_id: 'd56f7f1367bd6634605fd65997170252696178fa'
+ expects_source: "ppc64-diag"
  files:
   centos:
    '7.2':


### PR DESCRIPTION
Right now the ppc64-diag yaml was tied to an source tarball with 2.7.1 version
on its name. Removing this also requires to change the name of the expected
Source0 file in its spec.

Also adjustment is necessary in /ppc64-diag-2.4.3-scriptlocation.patch to make
it apply in the current repository state