### PR TITLE
[WIP]Skip tests (spec's %check) of docker, flannel, golang, gcc, kubernetes, libguestfs, libseccomp, libvirt.

### DIFF
--- a/docker/centOS/7.2/docker.spec
+++ b/docker/centOS/7.2/docker.spec
@@ -695,6 +695,7 @@ ln -s %{_sysconfdir}/rhsm/ca/redhat-uep.pem %{buildroot}/%{_sysconfdir}/%{name}/
 ln -s %{_sysconfdir}/rhsm/ca/redhat-uep.pem %{buildroot}/%{_sysconfdir}/%{name}/certs.d/redhat.io/redhat-ca.crt
 
 %check
+%if %{?skiptests:0}
 [ ! -w /run/%{repo}.sock ] || {
     mkdir test_dir
     pushd test_dir
@@ -704,6 +705,7 @@ ln -s %{_sysconfdir}/rhsm/ca/redhat-uep.pem %{buildroot}/%{_sysconfdir}/%{name}/
     popd
     popd
 }
+%endif
 
 %post
 %systemd_post %{repo}

--- a/flannel/centOS/7.2/flannel.spec
+++ b/flannel/centOS/7.2/flannel.spec
@@ -168,11 +168,15 @@ cp -pav {backend,pkg,subnet} %{buildroot}/%{gopath}/src/%{import_path}/
 %endif
 
 %check
+%if %{?skiptests:0}
+# the default behavior is to skip the tests, let's keep this piece in order to
+# preserve the default action even when we don't set skiptests
 %if 0%{?with_check}
 export GOPATH=${PWD}/_build:%{gopath}
 go test %{import_path}/pkg/ip
 #go test %{import_path}/remote
 go test %{import_path}/subnet
+%endif
 %endif
 
 %post

--- a/gcc/centOS/7.2/gcc.spec
+++ b/gcc/centOS/7.2/gcc.spec
@@ -2079,6 +2079,7 @@ rm -f %{buildroot}%{mandir}/man3/ffi*
 echo gcc-%{version}-%{release}.%{_arch} > $FULLPATH/rpmver
 
 %check
+%if %{?skiptests:0}
 cd obj-%{gcc_target_platform}
 
 %if %{build_java}
@@ -2105,6 +2106,7 @@ done
 tar cf - testlogs-%{_target_platform}-%{version}-%{release} | bzip2 -9c \
   | uuencode testlogs-%{_target_platform}.tar.bz2 || :
 rm -rf testlogs-%{_target_platform}-%{version}-%{release}
+%endif
 
 %clean
 rm -rf %{buildroot}

--- a/golang/centOS/7.2/golang.spec
+++ b/golang/centOS/7.2/golang.spec
@@ -420,6 +420,9 @@ cp -av %{SOURCE102} $RPM_BUILD_ROOT%{_rpmconfigdir}/macros.d/macros.golang
 
 
 %check
+%if %{?skiptests:0}
+# the default behavior is to skip the tests, let's keep this piece in order to
+# preserve the default action even when we don't set skiptests
 %if %{runtests}
 export GOROOT=$(pwd -P)
 export PATH="$GOROOT"/bin:"$PATH"
@@ -446,7 +449,7 @@ export GO_TEST_TIMEOUT_SCALE=2
 cd ..
 
 %endif
-
+%endif
 
 %post bin
 %{_sbindir}/update-alternatives --install %{_bindir}/go \

--- a/kubernetes/centOS/7.2/kubernetes.spec
+++ b/kubernetes/centOS/7.2/kubernetes.spec
@@ -728,6 +728,7 @@ cp -a *.md %{buildroot}%{_sharedstatedir}/kubernetes-unit-test/
 popd
 
 %check
+%if %{?skiptests:0}
 # Fedora, RHEL7 and CentOS are tested via unit-test subpackage
 if [ 1 != 1 ]; then
 echo "******Testing the commands*****"
@@ -746,6 +747,7 @@ fi
 
 #define license tag if not already defined
 %{!?_licensedir:%global license %doc}
+%endif
 
 %files
 # empty as it depends on master and node

--- a/libguestfs/centOS/7.2/libguestfs.spec
+++ b/libguestfs/centOS/7.2/libguestfs.spec
@@ -982,7 +982,8 @@ gzip -9 ChangeLog
 
 
 %check
-
+%if %{?skiptests:0}
+# keep the original behavior
 %if %{runtests}
 
 # Enable debugging - very useful if a test does fail, although
@@ -1048,7 +1049,7 @@ fi
 make check -k
 
 %endif
-
+%endif
 
 %install
 # 'INSTALLDIRS' ensures that Perl and Ruby libs are installed in the

--- a/libseccomp/centOS/7.2/libseccomp.spec
+++ b/libseccomp/centOS/7.2/libseccomp.spec
@@ -60,7 +60,9 @@ make V=1 DESTDIR="%{buildroot}" install
 rm -f "%{buildroot}/%{_libdir}/libseccomp.la"
 
 %check
+%if %{?skiptests:0}
 make V=1 check
+%endif
 
 %post -p /sbin/ldconfig
 

--- a/libvirt/centOS/7.2/libvirt.spec
+++ b/libvirt/centOS/7.2/libvirt.spec
@@ -1658,6 +1658,7 @@ rm -f $RPM_BUILD_ROOT%{_prefix}/lib/sysctl.d/60-libvirtd.conf
 rm -fr %{buildroot}
 
 %check
+%if %{?skiptests:0}
 cd tests
 make
 # These tests don't current work in a mock build root
@@ -1673,6 +1674,7 @@ then
   cat test-suite.log || true
   exit 1
 fi
+%endif
 
 %if %{with_libvirtd}
 %pre daemon


### PR DESCRIPTION
In order to use this feature we need to use the `--mock-args` feature implemented in open-power-host-os/builds#123 as follows:
```--mock-args "--define 'skiptests 0' "``` or
```--mock-args "--define 'skiptests %{nil}' "```
The value defined doesn't really matter since the test in the spec is for its definition.

For instance gcc build is almost 60% quicker (the commits messages of packages which have tests contains such information)

Note: Not all the packages got the skiptests feature since not all of the have the %check phase.