### PR TITLE
Make possible to skip tests (check phase)

### DIFF
--- a/docker/centOS/7/docker.spec
+++ b/docker/centOS/7/docker.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 %if 0%{?fedora}
 %global with_devel 1
 %global with_debug 1
@@ -694,6 +699,7 @@ mkdir -p %{buildroot}/etc/%{name}/certs.d/redhat.{com,io}
 ln -s %{_sysconfdir}/rhsm/ca/redhat-uep.pem %{buildroot}/%{_sysconfdir}/%{name}/certs.d/redhat.com/redhat-ca.crt
 ln -s %{_sysconfdir}/rhsm/ca/redhat-uep.pem %{buildroot}/%{_sysconfdir}/%{name}/certs.d/redhat.io/redhat-ca.crt
 
+%if %{with tests}
 %check
 [ ! -w /run/%{repo}.sock ] || {
     mkdir test_dir
@@ -704,6 +710,7 @@ ln -s %{_sysconfdir}/rhsm/ca/redhat-uep.pem %{buildroot}/%{_sysconfdir}/%{name}/
     popd
     popd
 }
+%endif
 
 %post
 %systemd_post %{repo}

--- a/flannel/centOS/7/flannel.spec
+++ b/flannel/centOS/7/flannel.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 %global with_devel 0
 %global with_bundled 1
 %global with_debug 1
@@ -167,12 +172,14 @@ install -d -p %{buildroot}/%{gopath}/src/%{import_path}/
 cp -pav {backend,pkg,subnet} %{buildroot}/%{gopath}/src/%{import_path}/
 %endif
 
+%if %{with tests}
 %check
 %if 0%{?with_check}
 export GOPATH=${PWD}/_build:%{gopath}
 go test %{import_path}/pkg/ip
 #go test %{import_path}/remote
 go test %{import_path}/subnet
+%endif
 %endif
 
 %post

--- a/gcc/centOS/7/gcc.spec
+++ b/gcc/centOS/7/gcc.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 %global DATE 20150702
 %global SVNREV 225304
 # Note, gcc_release must be integer, if you want to add suffixes to
@@ -2078,6 +2083,7 @@ rm -f %{buildroot}%{mandir}/man3/ffi*
 # Help plugins find out nvra.
 echo gcc-%{version}-%{release}.%{_arch} > $FULLPATH/rpmver
 
+%if %{with tests}
 %check
 cd obj-%{gcc_target_platform}
 
@@ -2105,6 +2111,7 @@ done
 tar cf - testlogs-%{_target_platform}-%{version}-%{release} | bzip2 -9c \
   | uuencode testlogs-%{_target_platform}.tar.bz2 || :
 rm -rf testlogs-%{_target_platform}-%{version}-%{release}
+%endif
 
 %clean
 rm -rf %{buildroot}

--- a/golang-github-russross-blackfriday/centOS/7/golang-github-russross-blackfriday.spec
+++ b/golang-github-russross-blackfriday/centOS/7/golang-github-russross-blackfriday.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 %global debug_package   %{nil}
 %global provider        github
 %global provider_tld    com
@@ -52,7 +57,9 @@ install -d -p %{buildroot}%{gopath}/src/%{import_path}/testdata
 cp -pav *.go %{buildroot}%{gopath}/src/%{import_path}/
 cp -pav testdata/* %{buildroot}%{gopath}/src/%{import_path}/testdata/
 
+%if %{with tests}
 %check
+%endif
 
 %files devel
 %doc README.md

--- a/golang-github-shurcooL-sanitized_anchor_name/centOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
+++ b/golang-github-shurcooL-sanitized_anchor_name/centOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 %global debug_package   %{nil}
 %global provider        github
 %global provider_tld    com
@@ -49,7 +54,9 @@ building other packages which use %{project}/%{repo}.
 install -d -p %{buildroot}/%{gopath}/src/%{import_path}/
 cp -pav *.go %{buildroot}/%{gopath}/src/%{import_path}/
 
+%if %{with tests}
 %check
+%endif
 
 %files devel
 %doc README.md LICENSE

--- a/golang/centOS/7/golang.spec
+++ b/golang/centOS/7/golang.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 # build ids are not currently generated:
 # https://code.google.com/p/go/issues/detail?id=5238
 #
@@ -418,7 +423,7 @@ mkdir -p $RPM_BUILD_ROOT%{_rpmconfigdir}/macros.d
 cp -av %{SOURCE102} $RPM_BUILD_ROOT%{_rpmconfigdir}/macros.d/macros.golang
 %endif
 
-
+%if %{with tests}
 %check
 %if %{runtests}
 export GOROOT=$(pwd -P)
@@ -445,6 +450,7 @@ export GO_TEST_TIMEOUT_SCALE=2
 %endif
 cd ..
 
+%endif
 %endif
 
 

--- a/kubernetes/centOS/7/kubernetes.spec
+++ b/kubernetes/centOS/7/kubernetes.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 %if 0%{?fedora}
 %global with_devel 1
 %global with_bundled 1
@@ -727,6 +732,7 @@ done
 cp -a *.md %{buildroot}%{_sharedstatedir}/kubernetes-unit-test/
 popd
 
+%if %{with tests}
 %check
 # Fedora, RHEL7 and CentOS are tested via unit-test subpackage
 if [ 1 != 1 ]; then
@@ -743,6 +749,7 @@ echo "******Testing integration******"
 hack/test-integration.sh --use_go_build
 %endif
 fi
+%endif
 
 #define license tag if not already defined
 %{!?_licensedir:%global license %doc}

--- a/libseccomp/centOS/7/libseccomp.spec
+++ b/libseccomp/centOS/7/libseccomp.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default. 
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 Summary: Enhanced seccomp library
 Name: libseccomp
 %define ibm_release %{?repo}.1
@@ -59,8 +64,10 @@ mkdir -p "%{buildroot}/%{_mandir}"
 make V=1 DESTDIR="%{buildroot}" install
 rm -f "%{buildroot}/%{_libdir}/libseccomp.la"
 
+%if %{with tests}
 %check
 make V=1 check
+%endif
 
 %post -p /sbin/ldconfig
 

--- a/libvirt/centOS/7/libvirt.spec
+++ b/libvirt/centOS/7/libvirt.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 # -*- rpm-spec -*-
 
 # This spec file assumes you are building for Fedora 13 or newer,
@@ -1657,6 +1662,7 @@ rm -f $RPM_BUILD_ROOT%{_prefix}/lib/sysctl.d/60-libvirtd.conf
 %clean
 rm -fr %{buildroot}
 
+%if %{with tests}
 %check
 cd tests
 make
@@ -1673,6 +1679,7 @@ then
   cat test-suite.log || true
   exit 1
 fi
+%endif
 
 %if %{with_libvirtd}
 %pre daemon

--- a/oci-register-machine/centOS/7/oci-register-machine.spec
+++ b/oci-register-machine/centOS/7/oci-register-machine.spec
@@ -1,3 +1,8 @@
+# The tests are disabled by default.
+# Set --with tests or bcond_without to run tests.
+# Original behaviour is preserved.
+%bcond_with tests
+
 %if 0%{?fedora}
 %global with_devel 0
 %global with_bundled 0
@@ -142,6 +147,7 @@ done
 sort -u -o devel.file-list devel.file-list
 %endif
 
+%if %{with tests}
 %check
 %if 0%{?with_check} && 0%{?with_unit_test} && 0%{?with_devel}
 %if ! 0%{?with_bundled}
@@ -150,6 +156,7 @@ export GOPATH=%{buildroot}%{gopath}:%{gopath}
 export GOPATH=%{buildroot}%{gopath}:$(pwd)/Godeps/_workspace:%{gopath}
 %endif
 
+%endif
 %endif
 
 #define license tag if not already defined


### PR DESCRIPTION
In order to run tests (under %check at spec files) we need to add "--with tests", i.e.  at config.yaml, mock-args "--with tests".  The tests are disabled by default. Changes applied to spec files with %check phase defined. Original behaviour preserved.

Refer to https://github.com/open-power-host-os/versions/pull/75 for more details.