### PR TITLE
Fix kubernetes archive name

### DIFF
--- a/kubernetes/kubernetes.yaml
+++ b/kubernetes/kubernetes.yaml
@@ -10,7 +10,7 @@ Package:
  sources:
    - url:
       src: 'https://github.com/kubernetes/kubernetes/archive/4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353/kubernetes-4a3f9c5.tar.gz'
-      archive: 'kubernetes-4a3f9c5.tar.gz'
+      archive: 'kubernetes-4a3f9c5'
  files:
   centos:
    '7':


### PR DESCRIPTION
The kubernetes package main source is downloaded from an URL source,
whose "archive" attribute is currently not used. The build scripts will
be modified to use this attribute, and so it needs to be fixed to be
consistent with git's and hg's "archive" attribute, by removing the file
extension.