### PR TITLE
Set multiple sources for docker and kubernetes

### DIFF
--- a/docker/centOS/7/docker.spec
+++ b/docker/centOS/7/docker.spec
@@ -107,18 +107,18 @@ URL: https://%{provider}.%{provider_tld}/projectatomic/%{repo}
 #ExclusiveArch: %%{go_arches}
 ExclusiveArch: %{ix86} x86_64 %{arm} aarch64 ppc64le s390x %{mips}
 Source0: %{name}.tar.gz
-Source1: %{git1}/archive/%{commit1}/%{repo}-storage-setup-%{shortcommit1}.tar.gz
-Source2: %{git2}/archive/%{commit2}/%{repo}-selinux-%{shortcommit2}.tar.gz
-Source4: %{git4}/archive/%{commit4}/%{repo}-novolume-plugin-%{shortcommit4}.tar.gz
+Source1: %{repo}-storage-setup-%{commit1}.tar.gz
+Source2: container-selinux-%{commit2}.tar.gz
+Source4: %{repo}-novolume-plugin-%{commit4}.tar.gz
 Source5: %{repo}.service
 Source6: %{repo}.sysconfig
 Source7: %{repo}-storage.sysconfig
 Source8: %{repo}-logrotate.sh
 Source9: README.%{repo}-logrotate
 Source10: %{repo}-network.sysconfig
-Source11: %{git5}/archive/%{commit5}/v1.10-migrator-%{shortcommit5}.tar.gz
-Source12: %{git6}/archive/%{commit6}/runc-%{shortcommit6}.tar.gz
-Source13: %{git7}/archive/%{commit7}/containerd-%{shortcommit7}.tar.gz
+Source11: v1.10-migrator-%{commit5}.tar.gz
+Source12: runc-%{commit6}.tar.gz
+Source13: containerd-%{commit7}.tar.gz
 Source14: %{repo}-containerd.service
 Source15: v1.10-migrator-helper
 

--- a/docker/docker.yaml
+++ b/docker/docker.yaml
@@ -6,17 +6,28 @@ Package:
        commit_id: 'bb80604a0b200140a440675348c848a137a1b2e2'
        branch: '1.12.x'
        archive: 'docker'
+   - url:
+       src: 'https://github.com/projectatomic/docker-storage-setup/archive/194eca25fd0d180b62f3ecf1b7b408992fd6a083/docker-storage-setup-194eca2.tar.gz'
+       archive: 'docker-storage-setup-194eca2'
+   - url:
+       src: 'https://github.com/projectatomic/docker-selinux/archive/032bcda7b1eb6d9d75d3c0ce64d9d35cdb9c7b85/docker-selinux-032bcda.tar.gz'
+       archive: 'docker-selinux-032bcda'
+   - url:
+       src: 'https://github.com/projectatomic/docker-novolume-plugin/archive/c5212546ab01b4b7b62caba888d298ab63f53984/docker-novolume-plugin-c521254.tar.gz'
+       archive: 'docker-novolume-plugin-c521254'
+   - url:
+       src: 'https://github.com/docker/v1.10-migrator/archive/994c35cbf7ae094d4cb1230b85631ecedd77b0d8/v1.10-migrator-994c35c.tar.gz'
+       archive: 'v1.10-migrator-994c35c'
+   - url:
+       src: 'https://github.com/projectatomic/runc/archive/f509e5094de84a919e2e8ae316373689fb66c513/runc-f509e50.tar.gz'
+       archive: 'runc-f509e50'
+   - url:
+       src: 'https://github.com/docker/containerd/archive/0ac3cd1be170d180b2baed755e8f0da547ceb267/containerd-0ac3cd1.tar.gz'
+       archive: 'containerd-0ac3cd1'
  files:
   centos:
    '7':
     spec: 'centOS/7/docker.spec'
     build_files: 'centOS/7/SOURCES'
-    download_build_files:
-     - 'https://github.com/projectatomic/docker-storage-setup/archive/194eca25fd0d180b62f3ecf1b7b408992fd6a083/docker-storage-setup-194eca2.tar.gz'
-     - 'https://github.com/projectatomic/docker-selinux/archive/032bcda7b1eb6d9d75d3c0ce64d9d35cdb9c7b85/docker-selinux-032bcda.tar.gz'
-     - 'https://github.com/projectatomic/docker-novolume-plugin/archive/c5212546ab01b4b7b62caba888d298ab63f53984/docker-novolume-plugin-c521254.tar.gz'
-     - 'https://github.com/docker/v1.10-migrator/archive/994c35cbf7ae094d4cb1230b85631ecedd77b0d8/v1.10-migrator-994c35c.tar.gz'
-     - 'https://github.com/projectatomic/runc/archive/f509e5094de84a919e2e8ae316373689fb66c513/runc-f509e50.tar.gz'
-     - 'https://github.com/docker/containerd/archive/0ac3cd1be170d180b2baed755e8f0da547ceb267/containerd-0ac3cd1.tar.gz'
     build_dependencies:
      - golang

--- a/docker/docker.yaml
+++ b/docker/docker.yaml
@@ -6,24 +6,36 @@ Package:
        commit_id: 'bb80604a0b200140a440675348c848a137a1b2e2'
        branch: '1.12.x'
        archive: 'docker'
-   - url:
-       src: 'https://github.com/projectatomic/docker-storage-setup/archive/194eca25fd0d180b62f3ecf1b7b408992fd6a083/docker-storage-setup-194eca2.tar.gz'
-       archive: 'docker-storage-setup-194eca2'
-   - url:
-       src: 'https://github.com/projectatomic/docker-selinux/archive/032bcda7b1eb6d9d75d3c0ce64d9d35cdb9c7b85/docker-selinux-032bcda.tar.gz'
-       archive: 'docker-selinux-032bcda'
-   - url:
-       src: 'https://github.com/projectatomic/docker-novolume-plugin/archive/c5212546ab01b4b7b62caba888d298ab63f53984/docker-novolume-plugin-c521254.tar.gz'
-       archive: 'docker-novolume-plugin-c521254'
-   - url:
-       src: 'https://github.com/docker/v1.10-migrator/archive/994c35cbf7ae094d4cb1230b85631ecedd77b0d8/v1.10-migrator-994c35c.tar.gz'
-       archive: 'v1.10-migrator-994c35c'
-   - url:
-       src: 'https://github.com/projectatomic/runc/archive/f509e5094de84a919e2e8ae316373689fb66c513/runc-f509e50.tar.gz'
-       archive: 'runc-f509e50'
-   - url:
-       src: 'https://github.com/docker/containerd/archive/0ac3cd1be170d180b2baed755e8f0da547ceb267/containerd-0ac3cd1.tar.gz'
-       archive: 'containerd-0ac3cd1'
+   - git:
+       src: 'https://github.com/projectatomic/docker-storage-setup.git'
+       branch: 'master'
+       commit_id: '194eca25fd0d180b62f3ecf1b7b408992fd6a083'
+       archive: 'docker-storage-setup-194eca25fd0d180b62f3ecf1b7b408992fd6a083'
+   - git:
+       src: 'https://github.com/projectatomic/docker-selinux.git'
+       branch: 'master'
+       commit_id: '032bcda7b1eb6d9d75d3c0ce64d9d35cdb9c7b85'
+       archive: 'container-selinux-032bcda7b1eb6d9d75d3c0ce64d9d35cdb9c7b85'
+   - git:
+       src: 'https://github.com/projectatomic/docker-novolume-plugin.git'
+       branch: 'master'
+       commit_id: 'c5212546ab01b4b7b62caba888d298ab63f53984'
+       archive: 'docker-novolume-plugin-c5212546ab01b4b7b62caba888d298ab63f53984'
+   - git:
+       src: 'https://github.com/docker/v1.10-migrator.git'
+       branch: 'master'
+       commit_id: '994c35cbf7ae094d4cb1230b85631ecedd77b0d8'
+       archive: 'v1.10-migrator-994c35cbf7ae094d4cb1230b85631ecedd77b0d8'
+   - git:
+       src: 'https://github.com/projectatomic/runc.git'
+       branch: 'master'
+       commit_id: 'f509e5094de84a919e2e8ae316373689fb66c513'
+       archive: 'runc-f509e5094de84a919e2e8ae316373689fb66c513'
+   - git:
+       src: 'https://github.com/docker/containerd.git'
+       branch: 'master'
+       commit_id: '0ac3cd1be170d180b2baed755e8f0da547ceb267'
+       archive: 'containerd-0ac3cd1be170d180b2baed755e8f0da547ceb267'
  files:
   centos:
    '7':

--- a/kubernetes/centOS/7/kubernetes.spec
+++ b/kubernetes/centOS/7/kubernetes.spec
@@ -71,9 +71,9 @@ Summary:        Container cluster management
 License:        ASL 2.0
 URL:            %{import_path}
 ExclusiveArch:  x86_64 ppc64le
-Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
+Source0:        %{repo}-%{commit}.tar.gz
 Source1:        %{name}.tar.gz
-Source2:        https://%{con_provider_prefix}/archive/%{con_commit}/%{con_repo}-%{con_shortcommit}.tar.gz
+Source2:        %{con_repo}-%{con_commit}.tar.gz
 
 Source33:       genmanpages.sh
 Patch2:         Change-etcd-server-port.patch

--- a/kubernetes/centOS/7/kubernetes.spec
+++ b/kubernetes/centOS/7/kubernetes.spec
@@ -72,7 +72,7 @@ License:        ASL 2.0
 URL:            %{import_path}
 ExclusiveArch:  x86_64 ppc64le
 Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
-Source1:        %{k8s_repo}-%{k8s_shortcommit}.tar.gz
+Source1:        %{name}.tar.gz
 Source2:        https://%{con_provider_prefix}/archive/%{con_commit}/%{con_repo}-%{con_shortcommit}.tar.gz
 
 Source33:       genmanpages.sh
@@ -580,7 +580,7 @@ BuildRequires: golang >= 1.2-7
 Kubernetes client tools like kubectl
 
 %prep
-%setup -q -n %{k8s_repo}-%{k8s_commit} -T -b 1
+%setup -q -n %{name} -T -b 1
 %if 0%{?with_debug}
 %patch3 -p1
 %endif
@@ -601,27 +601,27 @@ rm -rf $dirs
 # move k8s code from Godeps
 mv Godeps/_workspace/src/k8s.io/kubernetes/* .
 # copy missing source code
-cp ../%{k8s_repo}-%{k8s_commit}/cmd/kube-apiserver/apiserver.go cmd/kube-apiserver/.
-cp ../%{k8s_repo}-%{k8s_commit}/cmd/kube-controller-manager/controller-manager.go cmd/kube-controller-manager/.
-cp ../%{k8s_repo}-%{k8s_commit}/cmd/kubelet/kubelet.go cmd/kubelet/.
-cp ../%{k8s_repo}-%{k8s_commit}/cmd/kube-proxy/proxy.go cmd/kube-proxy/.
-cp ../%{k8s_repo}-%{k8s_commit}/plugin/cmd/kube-scheduler/scheduler.go plugin/cmd/kube-scheduler/.
-cp -r ../%{k8s_repo}-%{k8s_commit}/cmd/kubectl cmd/.
+cp ../%{name}/cmd/kube-apiserver/apiserver.go cmd/kube-apiserver/.
+cp ../%{name}/cmd/kube-controller-manager/controller-manager.go cmd/kube-controller-manager/.
+cp ../%{name}/cmd/kubelet/kubelet.go cmd/kubelet/.
+cp ../%{name}/cmd/kube-proxy/proxy.go cmd/kube-proxy/.
+cp ../%{name}/plugin/cmd/kube-scheduler/scheduler.go plugin/cmd/kube-scheduler/.
+cp -r ../%{name}/cmd/kubectl cmd/.
 # copy hack directory
-cp -r ../%{k8s_repo}-%{k8s_commit}/hack .
-cp -r ../%{k8s_repo}-%{k8s_commit}/cluster .
+cp -r ../%{name}/hack .
+cp -r ../%{name}/cluster .
 # copy contrib directory
-cp -r ../%{k8s_repo}-%{k8s_commit}/contrib .
+cp -r ../%{name}/contrib .
 # copy contrib folder
 cp -r ../%{con_repo}-%{con_commit}/init contrib/.
 # copy docs
-cp -r ../%{k8s_repo}-%{k8s_commit}/docs/admin docs/.
-cp -r ../%{k8s_repo}-%{k8s_commit}/docs/man docs/.
+cp -r ../%{name}/docs/admin docs/.
+cp -r ../%{name}/docs/man docs/.
 # copy LICENSE and *.md
-cp ../%{k8s_repo}-%{k8s_commit}/LICENSE .
-cp ../%{k8s_repo}-%{k8s_commit}/*.md .
+cp ../%{name}/LICENSE .
+cp ../%{name}/*.md .
 # copy hyperkube
-cp -r ../%{k8s_repo}-%{k8s_commit}/cmd/hyperkube cmd/.
+cp -r ../%{name}/cmd/hyperkube cmd/.
 
 %patch2 -p1
 
@@ -721,7 +721,7 @@ sort -u -o devel.file-list devel.file-list
 
 # place files for unit-test rpm
 install -d -m 0755 %{buildroot}%{_sharedstatedir}/kubernetes-unit-test/
-pushd ../%{k8s_repo}-%{k8s_commit}
+pushd ../%{name}
 # basically, everything from the root directory is needed
 # unit-tests needs source code
 # integration tests needs docs and other files

--- a/kubernetes/centOS/7/kubernetes.spec
+++ b/kubernetes/centOS/7/kubernetes.spec
@@ -72,7 +72,7 @@ License:        ASL 2.0
 URL:            %{import_path}
 ExclusiveArch:  x86_64 ppc64le
 Source0:        https://%{provider_prefix}/archive/%{commit}/%{repo}-%{shortcommit}.tar.gz
-Source1:        https://%{k8s_provider_prefix}/archive/%{k8s_commit}/%{k8s_repo}-%{k8s_shortcommit}.tar.gz
+Source1:        %{k8s_repo}-%{k8s_shortcommit}.tar.gz
 Source2:        https://%{con_provider_prefix}/archive/%{con_commit}/%{con_repo}-%{con_shortcommit}.tar.gz
 
 Source33:       genmanpages.sh
@@ -933,7 +933,7 @@ getent passwd kube >/dev/null || useradd -r -g kube -d / -s /sbin/nologin \
   related: #1211266
 
 * Fri Oct 09 2015 jchaloup <jchaloup@redhat.com> - 1.1.0-0.39.alpha1.git5f38cb0
-- Add normalization of flags 
+- Add normalization of flags
   related: #1211266
 
 * Fri Oct 02 2015 jchaloup <jchaloup@redhat.com> - 1.1.0-0.38.alpha1.git5f38cb0

--- a/kubernetes/kubernetes.yaml
+++ b/kubernetes/kubernetes.yaml
@@ -6,12 +6,16 @@ Package:
       branch: 'release-1.2-stable-20160316'
       commit_id: '4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353'
       archive: 'kubernetes'
-   - url:
-      src: 'https://github.com/openshift/origin/archive/ef1caba064de975387860175c3138aad432cf356/origin-ef1caba.tar.gz'
-      archive: 'origin-ef1caba'
-   - url:
-      src: 'https://github.com/kubernetes/contrib/archive/18bb93d3509bd13a15639969c8b0ebe39a7f9b50/contrib-18bb93d.tar.gz'
-      archive: 'contrib-18bb93d'
+   - git:
+      src: 'https://github.com/openshift/origin.git'
+      branch: 'release-1.2'
+      commit_id: 'ef1caba064de975387860175c3138aad432cf356'
+      archive: 'origin-ef1caba064de975387860175c3138aad432cf356'
+   - git:
+      src: 'https://github.com/kubernetes/contrib.git'
+      branch: 'master'
+      commit_id: '18bb93d3509bd13a15639969c8b0ebe39a7f9b50'
+      archive: 'contrib-18bb93d3509bd13a15639969c8b0ebe39a7f9b50'
  files:
   centos:
    '7':

--- a/kubernetes/kubernetes.yaml
+++ b/kubernetes/kubernetes.yaml
@@ -5,7 +5,7 @@ Package:
       src: 'https://github.com/openshift/kubernetes.git'
       branch: 'release-1.2-stable-20160316'
       commit_id: '4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353'
-      archive: 'kubernetes-4a3f9c5'
+      archive: 'kubernetes'
  files:
   centos:
    '7':

--- a/kubernetes/kubernetes.yaml
+++ b/kubernetes/kubernetes.yaml
@@ -1,15 +1,10 @@
 Package:
  name: 'kubernetes'
-# Keeping this commented out cause the stable commit id used by centOS isn't
-# available in any branch in the default remote. We need to wait for the hook
-# functionality and or the ability to clone multiple repositories to get this
-# yaml in its best shape.
-# clone_url: 'https://github.com/kubernetes/kubernetes.git'
-# branch: 'release-1.2'
-# commit_id: '5cb86ee022267586db386f62781338b0483733b3'
  sources:
-   - url:
-      src: 'https://github.com/kubernetes/kubernetes/archive/4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353/kubernetes-4a3f9c5.tar.gz'
+   - git:
+      src: 'https://github.com/openshift/kubernetes.git'
+      branch: 'release-1.2-stable-20160316'
+      commit_id: '4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353'
       archive: 'kubernetes-4a3f9c5'
  files:
   centos:

--- a/kubernetes/kubernetes.yaml
+++ b/kubernetes/kubernetes.yaml
@@ -6,13 +6,16 @@ Package:
       branch: 'release-1.2-stable-20160316'
       commit_id: '4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353'
       archive: 'kubernetes'
+   - url:
+      src: 'https://github.com/openshift/origin/archive/ef1caba064de975387860175c3138aad432cf356/origin-ef1caba.tar.gz'
+      archive: 'origin-ef1caba'
+   - url:
+      src: 'https://github.com/kubernetes/contrib/archive/18bb93d3509bd13a15639969c8b0ebe39a7f9b50/contrib-18bb93d.tar.gz'
+      archive: 'contrib-18bb93d'
  files:
   centos:
    '7':
     spec: 'centOS/7/kubernetes.spec'
     build_files: 'centOS/7/SOURCES'
-    download_build_files:
-     - 'https://github.com/openshift/origin/archive/ef1caba064de975387860175c3138aad432cf356/origin-ef1caba.tar.gz'
-     - 'https://github.com/kubernetes/contrib/archive/18bb93d3509bd13a15639969c8b0ebe39a7f9b50/contrib-18bb93d.tar.gz'
     build_dependencies:
      - golang


### PR DESCRIPTION
Change the docker and kubernetes packages yaml files to use the new sources format, with a main git source and multiple url sources.