### PR TITLE
Add Git commit ID to lshw release field

### DIFF
--- a/lshw/centOS/7/lshw.spec
+++ b/lshw/centOS/7/lshw.spec
@@ -1,10 +1,13 @@
 # Conditional build (--with/--without option)
 #   --without gui
 
+%global commit f9bdcc342d525f8504b81a9a344d58f57aa9b5dc
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
 Summary: HardWare LiSter
 Name: lshw
 Version: B.02.18
-Release: 1
+Release: 1.%{shortcommit}
 Source: %{name}.tar.gz
 URL: http://lshw.ezix.org/
 License: GPL


### PR DESCRIPTION
The commit used is ahead of the version tag in the Git repository, so
its better to specify it.