### PR TITLE
Add git/mercurial/svn commit ID to RPM release number

### DIFF
--- a/SLOF/CentOS/7/SLOF.spec
+++ b/SLOF/CentOS/7/SLOF.spec
@@ -1,6 +1,9 @@
+%global commit          b2d56f3a322f2c6375a87d11274fbae1cde66ae8
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:           SLOF
 Version:        20160525
-Release:        3%{?dist}
+Release:        3.git%{shortcommit}%{?dist}
 Summary:        Slimline Open Firmware
 
 License:        BSD

--- a/crash/CentOS/7/crash.spec
+++ b/crash/CentOS/7/crash.spec
@@ -1,10 +1,13 @@
+%global commit          64531dc850f2840cedafa143fe051d2cfeae5247
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 #
 # crash core analysis suite
 #
 Summary: Kernel analysis utility for live systems, netdump, diskdump, kdump, LKCD or mcore dumpfiles
 Name: crash
 Version: 7.1.6
-Release: 1%{?dist}
+Release: 1.git%{shortcommit}%{?dist}
 License: GPLv3
 Group: Development/Debuggers
 Source: %{name}.tar.gz

--- a/docker-swarm/CentOS/7/docker-swarm.spec
+++ b/docker-swarm/CentOS/7/docker-swarm.spec
@@ -15,10 +15,12 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
+%global commit          a0fd82b90932741bda54245e990df433a9ee06a7
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           docker-swarm
 Version:        1.1.0
-Release:        1
+Release:        1.git%{shortcommit}
 Summary:        Docker-native clustering system
 License:        Apache-2.0
 Group:          System/Management

--- a/flannel/CentOS/7/flannel.spec
+++ b/flannel/CentOS/7/flannel.spec
@@ -25,7 +25,7 @@
 
 Name:           flannel
 Version:        0.5.5
-Release:        1%{?dist}
+Release:        1.git%{shortcommit}%{?dist}
 Summary:        Etcd address management agent for overlay networks
 License:        ASL 2.0
 URL:            https://%{import_path}

--- a/gcc/CentOS/7/gcc.spec
+++ b/gcc/CentOS/7/gcc.spec
@@ -3,7 +3,7 @@
 %bcond_with tests
 
 %global DATE 20150702
-%global SVNREV 225304
+%global SVNREV 240558
 # Note, gcc_release must be integer, if you want to add suffixes to
 # %{release}, append them after %{gcc_release} on Release: line.
 %global gcc_release 12
@@ -83,7 +83,7 @@ Name: gcc
 %global gcc_version 4.8.5
 %endif
 Version: 4.8.5
-Release: %{gcc_release}%{?dist}
+Release: %{gcc_release}.svn%{SVNREV}%{?dist}
 %if "%{version}" != "%{gcc_version}"
 %define gcc_provides %{gcc_version}-16%{?dist}
 %endif

--- a/ginger-base/CentOS/7/ginger-base.spec
+++ b/ginger-base/CentOS/7/ginger-base.spec
@@ -2,9 +2,12 @@
 %global with_systemd 1
 %endif
 
+%global commit          593bf276645a98717586c2b532e379b3cf050810
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:       ginger-base
 Version:    2.2.1
-Release:    11%{?dist}
+Release:    11.git%{shortcommit}%{?dist}
 Summary:    Wok plugin for base host management
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch

--- a/ginger/CentOS/7/ginger.spec
+++ b/ginger/CentOS/7/ginger.spec
@@ -1,6 +1,9 @@
+%global commit          50b2b552c0ee4cbca6004572830fac38e9954ba3
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:       ginger
 Version:    2.3.0
-Release:    13%{?dist}
+Release:    13.git%{shortcommit}%{?dist}
 Summary:    Host management plugin for Wok - Webserver Originated from Kimchi
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 Group:      System Environment/Base

--- a/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
+++ b/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
@@ -8,14 +8,14 @@
 %global project         russross
 %global repo            blackfriday
 %global import_path     %{provider}.%{provider_tld}/%{project}/%{repo}
-%global commit          77efab57b2f74dd3f9051c79752b2e8995c8b789
+%global commit          5f33e7b7878355cd2b7e6b8eefc48a5472c69f70
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gccgo_version  >= 5
 %global golang_version >= 1.2.1-3
 
 Name:       golang-%{provider}-%{project}-%{repo}
 Version:    1.2
-Release:    5s%{?dist}
+Release:    5s.git%{shortcommit}%{?dist}
 # Be ahead of Fedora
 Epoch:      1
 Summary:    Markdown processor implemented in Go

--- a/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
+++ b/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
@@ -8,7 +8,7 @@
 %global project         shurcooL
 %global repo            sanitized_anchor_name
 %global import_path     %{provider}.%{provider_tld}/%{project}/%{repo}
-%global commit          8e87604bec3c645a4eeaee97dfec9f25811ff20d
+%global commit          1dba4b3954bc059efc3991ec364f9f9a35f597d2
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gccgo_version  >= 5
 %global golang_version >= 1.2.1-3 

--- a/hwdata/CentOS/7/hwdata.spec
+++ b/hwdata/CentOS/7/hwdata.spec
@@ -1,3 +1,6 @@
+%global commit          625a1194eaf9b764985ebec3a5da78dc71299238
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 # This package is arch-specific just because of bundling different files for
 # different architectures. No -debuginfo package is needed.
 %global     debug_package %{nil}
@@ -5,7 +8,7 @@
 Name:       hwdata
 Summary:    Hardware identification and configuration data
 Version:    0.288
-Release:    1%{?dist}
+Release:    1.git%{shortcommit}%{?dist}
 License:    GPLv2+
 Group:      System Environment/Base
 Source0:    %{name}.tar.gz

--- a/kernel/CentOS/7/kernel.spec
+++ b/kernel/CentOS/7/kernel.spec
@@ -1,3 +1,6 @@
+%global commit          bbbdfd8db1fce91da2c7625742f80c268d6671be
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 # Implement magicdirs for ibm8 kernel configs
 ##{lua:
 #  sourcedir = rpm.expand("%{_sourcedir}")
@@ -311,7 +314,7 @@ Group: System Environment/Kernel
 License: GPLv2
 URL: http://www.kernel.org/
 Version: 4.10.0
-Release: 1%{?prerelease}%{?dist}
+Release: 1%{?prerelease}.git%{shortcommit}%{?dist}
 # DO NOT CHANGE THE 'ExclusiveArch' LINE TO TEMPORARILY EXCLUDE AN ARCHITECTURE BUILD.
 # SET %%nobuildarches (ABOVE) INSTEAD
 ExclusiveArch: noarch i686 x86_64 ppc ppc64 ppc64le s390 s390x %{arm} ppcnf ppc476

--- a/kimchi/CentOS/7/kimchi.spec
+++ b/kimchi/CentOS/7/kimchi.spec
@@ -1,6 +1,9 @@
+%global commit          4ea4cef057617b43381e7e3b913b4a34104cac40
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:       kimchi
 Version:    2.3.0
-Release:    12%{?dist}
+Release:    12.git%{shortcommit}%{?dist}
 Summary:    Kimchi server application
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch

--- a/librtas/CentOS/7/librtas.spec
+++ b/librtas/CentOS/7/librtas.spec
@@ -1,7 +1,10 @@
+%global commit          3fe4911fa9e456e6cae2f314cff46894025b7fb9
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Summary: Libraries to provide access to RTAS calls and RTAS events.
 Name: librtas
 Version: 1.4.1
-Release: 2%{?dist}
+Release: 2.git%{shortcommit}%{?dist}
 License: GNU Lesser General Public License (LGPL)
 Source:  %{name}.tar.gz
 Group: System Environment/Libraries

--- a/libservicelog/CentOS/7/libservicelog.spec
+++ b/libservicelog/CentOS/7/libservicelog.spec
@@ -1,6 +1,9 @@
+%global commit          48875ee8614eeefaa3d5d8ff92fb424915738169
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:           libservicelog
 Version:        1.1.16
-Release:        2%{?dist}
+Release:        2.git%{shortcommit}%{?dist}
 Summary:        Servicelog Database and Library
 
 Group:          System Environment/Libraries

--- a/libvirt/CentOS/7/libvirt.spec
+++ b/libvirt/CentOS/7/libvirt.spec
@@ -1,3 +1,6 @@
+%global commit          ddccbf6072a3f95e053cc9934d1178cb1acd2aa7
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 # The tests are disabled by default.
 # Set --with tests or bcond_without to run tests.
 %bcond_with tests
@@ -383,7 +386,7 @@
 Summary: Library providing a simple virtualization API
 Name: libvirt
 Version: 2.2.0
-Release: 6%{?dist}
+Release: 6.git%{shortcommit}%{?dist}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
 Source0: %{name}.tar.gz
 License: LGPLv2+

--- a/libvpd/CentOS/7/libvpd.spec
+++ b/libvpd/CentOS/7/libvpd.spec
@@ -1,6 +1,9 @@
+%global commit          8cb3fe06b8d2e6125235eb1973e624a0fb12837c
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:		libvpd
 Version:	2.2.5
-Release:	4%{?dist}
+Release:	4.git%{shortcommit}%{?dist}
 Summary:	VPD Database access library for lsvpd
 
 Group:		System Environment/Libraries

--- a/lshw/CentOS/7/lshw.spec
+++ b/lshw/CentOS/7/lshw.spec
@@ -7,7 +7,7 @@
 Summary: HardWare LiSter
 Name: lshw
 Version: B.02.18
-Release: 1.%{shortcommit}
+Release: 1.git%{shortcommit}
 Source: %{name}.tar.gz
 URL: http://lshw.ezix.org/
 License: GPL

--- a/lsvpd/CentOS/7/lsvpd.spec
+++ b/lsvpd/CentOS/7/lsvpd.spec
@@ -1,6 +1,9 @@
+%global commit          3a5f5e1fdf82ebc6efdda4cfc51fd24776bad8be
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:		lsvpd
 Version:	1.7.7
-Release:	6%{?dist}
+Release:	6.git%{shortcommit}%{?dist}
 Summary:	VPD/hardware inventory utilities for Linux
 Group:		Applications/System
 License:	GPLv2+

--- a/novnc/CentOS/7/novnc.spec
+++ b/novnc/CentOS/7/novnc.spec
@@ -1,6 +1,9 @@
+%global commit          fc00821eba469641c6c94706726c3d78e46460a2
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:           novnc
 Version:        0.5.1
-Release:        5%{?dist}
+Release:        5.git%{shortcommit}%{?dist}
 Summary:        VNC client using HTML5 (Web Sockets, Canvas) with encryption support
 Requires:       python-websockify
 

--- a/ppc64-diag/CentOS/7/ppc64-diag.spec
+++ b/ppc64-diag/CentOS/7/ppc64-diag.spec
@@ -1,6 +1,9 @@
+%global commit          d56f7f1367bd6634605fd65997170252696178fa
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:           ppc64-diag
 Version:        2.7.2
-Release:        1%{?dist}
+Release:        1.git%{shortcommit}%{?dist}
 Summary:        PowerLinux Platform Diagnostics
 URL:            http://sourceforge.net/projects/linux-diag/files/ppc64-diag/
 Group:          System Environment/Base

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -1,3 +1,6 @@
+%global commit          169a53efae579f51022612577e7b17c8aead237c
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 # Fakeroot only: this package is useful for development in fakeroots. It is not
 # available as a base package, though it may be delivered with an approved PCR.
 # We redefine base dist here to help this package stand out as fakeroot-only.
@@ -186,7 +189,7 @@
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 2.7.0
-Release: 9%{?dist}
+Release: 9.git%{shortcommit}%{?dist}
 Epoch: 15
 License: GPLv2+ and LGPLv2+ and BSD
 Group: Development/Tools

--- a/servicelog/CentOS/7/servicelog.spec
+++ b/servicelog/CentOS/7/servicelog.spec
@@ -1,6 +1,9 @@
+%global commit          7d33cd33507d6f11fb86c4bc13d752cb122759f7
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:           servicelog
 Version:        1.1.14
-Release:        4%{?dist}
+Release:        4.git%{shortcommit}%{?dist}
 Summary:        Servicelog Tools
 
 Group:          System Environment/Base

--- a/sos/CentOS/7/sos.spec
+++ b/sos/CentOS/7/sos.spec
@@ -1,9 +1,12 @@
+%global commit          52dd1dbc52783e622ca0a96e3e9c182bb26887fe
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 %{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Summary: A set of tools to gather troubleshooting information from a system
 Name: sos
 Version: 3.3
-Release: 18%{?dist}
+Release: 18.git%{shortcommit}%{?dist}
 Group: Applications/System
 Source0: %{name}.tar.gz
 License: GPLv2+

--- a/wok/CentOS/7/wok.spec
+++ b/wok/CentOS/7/wok.spec
@@ -1,6 +1,9 @@
+%global commit          0489d72cbf7f3f33da304ae83a7bacedcc1bb7d5
+%global shortcommit     %(c=%{commit}; echo ${c:0:7})
+
 Name:       wok
 Version:    2.3.0
-Release:    10%{?dist}
+Release:    10.git%{shortcommit}%{?dist}
 Summary:    Wok - Webserver Originated from Kimchi
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch


### PR DESCRIPTION
As agreed with the team, we only do this when the used commit ID
is not in a release branch or associated with a release tag.