### PR TITLE
Rename dependencies attribute to install_dependencies

### DIFF
--- a/golang-github-russross-blackfriday/golang-github-russross-blackfriday.yaml
+++ b/golang-github-russross-blackfriday/golang-github-russross-blackfriday.yaml
@@ -9,6 +9,6 @@ Package:
     build_dependencies:
      - golang
      - golang-github-shurcooL-sanitized_anchor_name
-    dependencies:
+    install_dependencies:
      - golang
      - golang-github-shurcooL-sanitized_anchor_name

--- a/golang-github-shurcooL-sanitized_anchor_name/golang-github-shurcooL-sanitized_anchor_name.yaml
+++ b/golang-github-shurcooL-sanitized_anchor_name/golang-github-shurcooL-sanitized_anchor_name.yaml
@@ -8,5 +8,5 @@ Package:
    '7':
     build_dependencies:
      - golang
-    dependencies:
+    install_dependencies:
      - golang

--- a/lsvpd/lsvpd.yaml
+++ b/lsvpd/lsvpd.yaml
@@ -10,7 +10,7 @@ Package:
  files:
   CentOS:
    '7':
-    dependencies:
+    install_dependencies:
      - 'libvpd'
     build_dependencies:
      - 'librtas'

--- a/servicelog/servicelog.yaml
+++ b/servicelog/servicelog.yaml
@@ -10,5 +10,5 @@ Package:
  files:
   CentOS:
    '7':
-    dependencies:
+    install_dependencies:
      - 'libservicelog'


### PR DESCRIPTION
Current naming is confusing because we also have build dependencies.
New name makes clearer the difference between both.