### PR TITLE
Use hostos-devel branch for slof

### DIFF
--- a/SLOF/CentOS/7/SLOF.spec
+++ b/SLOF/CentOS/7/SLOF.spec
@@ -1,8 +1,8 @@
-%global commit          b2d56f3a322f2c6375a87d11274fbae1cde66ae8
+%global commit          efd65f49929d7db775b26066d538c8120ae3db94
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 Name:           SLOF
-Version:        20160525
+Version:        20161019
 Release:        3.git%{shortcommit}%{?dist}
 Summary:        Slimline Open Firmware
 
@@ -57,6 +57,9 @@ cp -a boot_rom.bin $RPM_BUILD_ROOT%{_datadir}/qemu/slof.bin
 
 
 %changelog
+* Wed Feb  8 2017 Nikunj A. Dadhania <nikunj@linux.vnet.ibm.com> - 20161019
+- Pull upstream SLOF present in qemu 2.8
+
 * Thu Nov 3 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 20160525-3
 - Spec cleanup
 

--- a/SLOF/SLOF.yaml
+++ b/SLOF/SLOF.yaml
@@ -2,9 +2,9 @@ Package:
  sources:
   - git:
      src: 'https://github.com/open-power-host-os/slof.git'
-     branch: 'powerkvm-v3.1.1'
-     # this is tag qemu-slof-20160525 but since nobody else uses tags let's keep it as a commit id
-     commit_id: 'b2d56f3a322f2c6375a87d11274fbae1cde66ae8'
+     branch: 'hostos-devel'
+     # this is tag qemu-slof-20161019 but since nobody else uses tags let's keep it as a commit id
+     commit_id: 'efd65f49929d7db775b26066d538c8120ae3db94'
  files:
   CentOS:
    '7':


### PR DESCRIPTION
And update to upstream slof available in qemu-2.8

Signed-off-by: Nikunj A Dadhania <nikunj@linux.vnet.ibm.com>