### PR TITLE
Fix specs to allow automatic version upgrade

### DIFF
--- a/SLOF/CentOS/7/SLOF.spec
+++ b/SLOF/CentOS/7/SLOF.spec
@@ -1,9 +1,10 @@
 %global commit          efd65f49929d7db775b26066d538c8120ae3db94
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:           SLOF
 Version:        20161019
-Release:        3.git%{shortcommit}%{?dist}
+Release:        3%{gitcommittag}%{?dist}
 Summary:        Slimline Open Firmware
 
 License:        BSD

--- a/crash/CentOS/7/crash.spec
+++ b/crash/CentOS/7/crash.spec
@@ -1,5 +1,6 @@
 %global commit          64531dc850f2840cedafa143fe051d2cfeae5247
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 #
 # crash core analysis suite
@@ -7,7 +8,7 @@
 Summary: Kernel analysis utility for live systems, netdump, diskdump, kdump, LKCD or mcore dumpfiles
 Name: crash
 Version: 7.1.6
-Release: 1.git%{shortcommit}%{?dist}
+Release: 1%{gitcommittag}%{?dist}
 License: GPLv3
 Group: Development/Debuggers
 Source: %{name}.tar.gz

--- a/crash/CentOS/7/crash.spec
+++ b/crash/CentOS/7/crash.spec
@@ -215,7 +215,7 @@ rm -rf %{buildroot}
 - Add ARM to the Exclusive arch
 
 * Fri Feb 25 2011 Dave Anderson <anderson@redhat.com> - 5.1.2-2
-- Fixes for gcc-4.6 -Werror compile failures in gdb module.  
+- Fixes for gcc-4.6 -Werror compile failures in gdb module.
 
 * Wed Feb 23 2011 Dave Anderson <anderson@redhat.com> - 5.1.2-1
 - Upstream version.
@@ -233,8 +233,8 @@ rm -rf %{buildroot}
   Bump version.
 
 * Fri Sep 11 2009 Dave Anderson <anderson@redhat.com> - 4.0.9-1
-- Update to upstream release, which allows the removal of the 
-  Revision tag workaround, the crash-4.0-8.11-dwarf3.patch and 
+- Update to upstream release, which allows the removal of the
+  Revision tag workaround, the crash-4.0-8.11-dwarf3.patch and
   the crash-4.0-8.11-optflags.patch
 
 * Wed Aug 05 2009 Lubomir Rintel <lkundrak@v3.sk> - 4.0.8.11-2
@@ -313,7 +313,7 @@ rm -rf %{buildroot}
   by lkcd_x86_trace.c; also for BZ #191719
 
 * Mon May 15 2006 Dave Anderson <anderson@redhat.com> - 4.0-2.26.1
-- Updated crash.patch to bring it up to 4.0-2.26, which should 
+- Updated crash.patch to bring it up to 4.0-2.26, which should
   address BZ #191719 - "crash fails to build in mock"
 
 * Tue Feb 07 2006 Jesse Keating <jkeating@redhat.com> - 4.0-2.18.1
@@ -362,7 +362,7 @@ rm -rf %{buildroot}
 - bump release for fc3
 
 * Tue Jul 13 2004 Dave Anderson <anderson@redhat.com> 3.8-4
-- Fix for gcc 3.4.x/gdb issue where vmlinux was mistakenly presumed non-debug 
+- Fix for gcc 3.4.x/gdb issue where vmlinux was mistakenly presumed non-debug
 
 * Fri Jun 25 2004 Dave Anderson <anderson@redhat.com> 3.8-3
 - remove (harmless) error message during ia64 diskdump invocation when
@@ -370,9 +370,9 @@ rm -rf %{buildroot}
 - several 2.6 kernel specific updates
 
 * Thu Jun 17 2004 Dave Anderson <anderson@redhat.com> 3.8-2
-- updated source package to crash-3.8.tar.gz 
+- updated source package to crash-3.8.tar.gz
 - diskdump support
-- x86_64 processor support 
+- x86_64 processor support
 
 * Mon Sep 22 2003 Dave Anderson <anderson@redhat.com> 3.7-5
 - make bt recovery code start fix-up only upon reaching first faulting frame
@@ -384,14 +384,14 @@ rm -rf %{buildroot}
 - patch to recognize per-cpu GDT changes that redefine __KERNEL_CS and DS
 
 * Wed Sep 10 2003 Dave Anderson <anderson@redhat.com> 3.7-2
-- patches for netdump active_set determination and slab info gathering 
+- patches for netdump active_set determination and slab info gathering
 
 * Wed Aug 20 2003 Dave Anderson <anderson@redhat.com> 3.7-1
 - updated source package to crash-3.7.tar.gz
 
 * Wed Jul 23 2003 Dave Anderson <anderson@redhat.com> 3.6-1
 - removed Packager, Distribution, and Vendor tags
-- updated source package to crash-3.6.tar.gz 
+- updated source package to crash-3.6.tar.gz
 
 * Fri Jul 18 2003 Jay Fenlason <fenlason@redhat.com> 3.5-2
 - remove ppc from arch list, since it doesn't work with ppc64 kernels

--- a/docker-swarm/CentOS/7/docker-swarm.spec
+++ b/docker-swarm/CentOS/7/docker-swarm.spec
@@ -17,10 +17,11 @@
 
 %global commit          a0fd82b90932741bda54245e990df433a9ee06a7
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:           docker-swarm
 Version:        1.1.0
-Release:        1.git%{shortcommit}
+Release:        1%{gitcommittag}
 Summary:        Docker-native clustering system
 License:        Apache-2.0
 Group:          System/Management

--- a/flannel/CentOS/7/flannel.spec
+++ b/flannel/CentOS/7/flannel.spec
@@ -20,12 +20,13 @@
 %global import_path     %{provider}.%{provider_tld}/%{project}/%{repo}
 %global commit          cb8284fb60737793596dd2fc98d9608d3d0d66f0
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 %global devel_main      flannel-devel
 
 Name:           flannel
 Version:        0.5.5
-Release:        1.git%{shortcommit}%{?dist}
+Release:        1%{gitcommittag}%{?dist}
 Summary:        Etcd address management agent for overlay networks
 License:        ASL 2.0
 URL:            https://%{import_path}

--- a/ginger-base/CentOS/7/ginger-base.spec
+++ b/ginger-base/CentOS/7/ginger-base.spec
@@ -4,10 +4,11 @@
 
 %global commit          593bf276645a98717586c2b532e379b3cf050810
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:       ginger-base
 Version:    2.2.1
-Release:    11.git%{shortcommit}%{?dist}
+Release:    11%{gitcommittag}%{?dist}
 Summary:    Wok plugin for base host management
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch

--- a/ginger/CentOS/7/ginger.spec
+++ b/ginger/CentOS/7/ginger.spec
@@ -1,9 +1,10 @@
 %global commit          c840545a470e9b55e2bbb4d6a048ed67229c4891
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:       ginger
 Version:    2.3.0
-Release:    14.git%{shortcommit}%{?dist}
+Release:    14%{gitcommittag}%{?dist}
 Summary:    Host management plugin for Wok - Webserver Originated from Kimchi
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 Group:      System Environment/Base

--- a/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
+++ b/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
@@ -10,12 +10,13 @@
 %global import_path     %{provider}.%{provider_tld}/%{project}/%{repo}
 %global commit          5f33e7b7878355cd2b7e6b8eefc48a5472c69f70
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 %global gccgo_version  >= 5
 %global golang_version >= 1.2.1-3
 
 Name:       golang-%{provider}-%{project}-%{repo}
 Version:    1.2
-Release:    5s.git%{shortcommit}%{?dist}
+Release:    5s%{gitcommittag}%{?dist}
 # Be ahead of Fedora
 Epoch:      1
 Summary:    Markdown processor implemented in Go

--- a/hwdata/CentOS/7/hwdata.spec
+++ b/hwdata/CentOS/7/hwdata.spec
@@ -1,5 +1,6 @@
 %global commit          625a1194eaf9b764985ebec3a5da78dc71299238
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 # This package is arch-specific just because of bundling different files for
 # different architectures. No -debuginfo package is needed.
@@ -8,7 +9,7 @@
 Name:       hwdata
 Summary:    Hardware identification and configuration data
 Version:    0.288
-Release:    1.git%{shortcommit}%{?dist}
+Release:    1%{gitcommittag}%{?dist}
 License:    GPLv2+
 Group:      System Environment/Base
 Source0:    %{name}.tar.gz

--- a/kernel/CentOS/7/kernel.spec
+++ b/kernel/CentOS/7/kernel.spec
@@ -1,5 +1,6 @@
 %global commit          bbbdfd8db1fce91da2c7625742f80c268d6671be
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 # Implement magicdirs for ibm8 kernel configs
 ##{lua:
@@ -314,7 +315,7 @@ Group: System Environment/Kernel
 License: GPLv2
 URL: http://www.kernel.org/
 Version: 4.10.0
-Release: 1%{?prerelease}.git%{shortcommit}%{?dist}
+Release: 1%{?prerelease}%{gitcommittag}%{?dist}
 # DO NOT CHANGE THE 'ExclusiveArch' LINE TO TEMPORARILY EXCLUDE AN ARCHITECTURE BUILD.
 # SET %%nobuildarches (ABOVE) INSTEAD
 ExclusiveArch: noarch i686 x86_64 ppc ppc64 ppc64le s390 s390x %{arm} ppcnf ppc476

--- a/kimchi/CentOS/7/kimchi.spec
+++ b/kimchi/CentOS/7/kimchi.spec
@@ -1,9 +1,10 @@
 %global commit          ec17672b98a4723aa42c6fc114b3d428b66dcab4
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:       kimchi
 Version:    2.3.0
-Release:    13.git%{shortcommit}%{?dist}
+Release:    13%{gitcommittag}%{?dist}
 Summary:    Kimchi server application
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch

--- a/librtas/CentOS/7/librtas.spec
+++ b/librtas/CentOS/7/librtas.spec
@@ -1,10 +1,11 @@
 %global commit          3fe4911fa9e456e6cae2f314cff46894025b7fb9
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Summary: Libraries to provide access to RTAS calls and RTAS events.
 Name: librtas
 Version: 1.4.1
-Release: 2.git%{shortcommit}%{?dist}
+Release: 2%{gitcommittag}%{?dist}
 License: GNU Lesser General Public License (LGPL)
 Source:  %{name}.tar.gz
 Group: System Environment/Libraries
@@ -79,4 +80,3 @@ ldconfig
 * Thu Nov 3 2016 Mauro S. M. Rodrigues <maurosr@linux.vnet.ibm.com> - 1.4.1-2
 - added changelog section
 - spec cleanup
-

--- a/libservicelog/CentOS/7/libservicelog.spec
+++ b/libservicelog/CentOS/7/libservicelog.spec
@@ -1,9 +1,10 @@
 %global commit          48875ee8614eeefaa3d5d8ff92fb424915738169
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:           libservicelog
 Version:        1.1.16
-Release:        2.git%{shortcommit}%{?dist}
+Release:        2%{gitcommittag}%{?dist}
 Summary:        Servicelog Database and Library
 
 Group:          System Environment/Libraries
@@ -145,4 +146,3 @@ Resolves: rhbz#1048877
 
 * Fri Feb 20 2009 Roman Rakus <rrakus@redhat.com> - 1.0.1-1
 - Initial packaging
-

--- a/libvirt/CentOS/7/libvirt.spec
+++ b/libvirt/CentOS/7/libvirt.spec
@@ -1,5 +1,6 @@
 %global commit          ddccbf6072a3f95e053cc9934d1178cb1acd2aa7
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 # The tests are disabled by default.
 # Set --with tests or bcond_without to run tests.
@@ -386,7 +387,7 @@
 Summary: Library providing a simple virtualization API
 Name: libvirt
 Version: 2.2.0
-Release: 6.git%{shortcommit}%{?dist}
+Release: 6%{gitcommittag}%{?dist}
 ExclusiveArch: ppc64 ppc64le x86_64 s390x
 Source0: %{name}.tar.gz
 License: LGPLv2+

--- a/libvpd/CentOS/7/libvpd.spec
+++ b/libvpd/CentOS/7/libvpd.spec
@@ -1,9 +1,10 @@
 %global commit          8cb3fe06b8d2e6125235eb1973e624a0fb12837c
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:		libvpd
 Version:	2.2.5
-Release:	4.git%{shortcommit}%{?dist}
+Release:	4%{gitcommittag}%{?dist}
 Summary:	VPD Database access library for lsvpd
 
 Group:		System Environment/Libraries

--- a/lshw/CentOS/7/lshw.spec
+++ b/lshw/CentOS/7/lshw.spec
@@ -3,11 +3,12 @@
 
 %global commit f9bdcc342d525f8504b81a9a344d58f57aa9b5dc
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag .git%{shortcommit}
 
 Summary: HardWare LiSter
 Name: lshw
 Version: B.02.18
-Release: 1.git%{shortcommit}
+Release: 1%{gitcommittag}
 Source: %{name}.tar.gz
 URL: http://lshw.ezix.org/
 License: GPL

--- a/lsvpd/CentOS/7/lsvpd.spec
+++ b/lsvpd/CentOS/7/lsvpd.spec
@@ -1,9 +1,10 @@
 %global commit          3a5f5e1fdf82ebc6efdda4cfc51fd24776bad8be
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:		lsvpd
 Version:	1.7.7
-Release:	6.git%{shortcommit}%{?dist}
+Release:	6%{gitcommittag}%{?dist}
 Summary:	VPD/hardware inventory utilities for Linux
 Group:		Applications/System
 License:	GPLv2+

--- a/lsvpd/CentOS/7/lsvpd.spec
+++ b/lsvpd/CentOS/7/lsvpd.spec
@@ -210,7 +210,7 @@ on POWER PC based systems.
 - Removing unnecessary Requires field
 
 * Fri Nov 16 2007 - Eric Munson <ebmunson@us.ibm.com> - 1.4.0-1
-- Removing udev rules from install as they are causing problems.  Hotplug 
+- Removing udev rules from install as they are causing problems.  Hotplug
   will be disabled until we find a smarter way of handling it.
 - Updating License
 - Adjusting the way vpdupdater is inserted into run control

--- a/novnc/CentOS/7/novnc.spec
+++ b/novnc/CentOS/7/novnc.spec
@@ -1,9 +1,10 @@
 %global commit          fc00821eba469641c6c94706726c3d78e46460a2
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:           novnc
 Version:        0.5.1
-Release:        5.git%{shortcommit}%{?dist}
+Release:        5%{gitcommittag}%{?dist}
 Summary:        VNC client using HTML5 (Web Sockets, Canvas) with encryption support
 Requires:       python-websockify
 

--- a/ppc64-diag/CentOS/7/ppc64-diag.spec
+++ b/ppc64-diag/CentOS/7/ppc64-diag.spec
@@ -1,9 +1,10 @@
 %global commit          d56f7f1367bd6634605fd65997170252696178fa
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:           ppc64-diag
 Version:        2.7.2
-Release:        1.git%{shortcommit}%{?dist}
+Release:        1%{gitcommittag}%{?dist}
 Summary:        PowerLinux Platform Diagnostics
 URL:            http://sourceforge.net/projects/linux-diag/files/ppc64-diag/
 Group:          System Environment/Base

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -1,5 +1,6 @@
 %global commit          bb80805d7d5b14e886e769b5938b459a3592d882
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 # Fakeroot only: this package is useful for development in fakeroots. It is not
 # available as a base package, though it may be delivered with an approved PCR.
@@ -189,7 +190,7 @@
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 2.8.0
-Release: 1.git%{shortcommit}%{?dist}
+Release: 1%{gitcommittag}%{?dist}
 Epoch: 15
 License: GPLv2+ and LGPLv2+ and BSD
 Group: Development/Tools

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -1,4 +1,4 @@
-%global commit          169a53efae579f51022612577e7b17c8aead237c
+%global commit          bb80805d7d5b14e886e769b5938b459a3592d882
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 
 # Fakeroot only: this package is useful for development in fakeroots. It is not
@@ -188,8 +188,8 @@
 
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
-Version: 2.7.0
-Release: 9.git%{shortcommit}%{?dist}
+Version: 2.8.0
+Release: 1.git%{shortcommit}%{?dist}
 Epoch: 15
 License: GPLv2+ and LGPLv2+ and BSD
 Group: Development/Tools
@@ -1174,8 +1174,6 @@ getent passwd qemu >/dev/null || \
 %doc %{qemudocdir}/Changelog
 %doc %{qemudocdir}/README
 %doc %{qemudocdir}/qemu-doc.html
-%doc %{qemudocdir}/qemu-tech.html
-%doc %{qemudocdir}/qmp-commands.txt
 %doc %{qemudocdir}/COPYING
 %doc %{qemudocdir}/COPYING.LIB
 %doc %{qemudocdir}/LICENSE
@@ -1531,6 +1529,22 @@ getent passwd qemu >/dev/null || \
 %endif
 
 %changelog
+* Tue Feb 14 2017 Olav Philipp Henschel <olavph@linux.vnet.ibm.com> - 15:2.8.0-1.gitbb80805
+- Version update
+- Removed files qemu-tech.html and qmp-commands.txt that are not generated anymore
+- bb80805d7d5b14e886e769b5938b459a3592d882 vfio/pci: Add support for mmapping MSI-X table
+- 9feef08e90c83ee1a0174702e7275e6bdde7dd47 Merge tag v2.8.0 into hostos-devel
+- f23c070fbdaa6c594bf4ff70c81e5a59ae64f8b3 Revert spapr_pci: Add numa node id
+- 8211cc28de6f87aac44b2d23eeab9bd28216fe3e Revert RAMBlocks: Store page size
+- df8977f5ad5511d65bc04844280fd67b9067a0b7 Revert migration/postcopy: Explicitly disallow huge pages
+- b55d4399dd23e7ad6f51f96acd509bfc0a17ffb6 Revert virtio-pci: error out when both legacy and modern modes are disabled
+- 5560283f5f1aeb846eabe03e7fe9b7c7bce5ad26 Revert vfio: Add support for mmapping sub-page MMIO BARs
+- 8261d330398931852c80da9b6ceef455f4785260 Revert spapr_pci: advertise explicit numa IDs even when theres 1 node
+- beefae50a9dbdc5f268edec0718dd6416481a4e6 Revert vhost: adapt vhost_verify_ring_mappings() to virtio 1 ring layout
+- 76d98639598c7cde6f728642c26596c96361df1a Revert vhost: drop legacy vring layout bits
+- 36cffb0c3b91c5da64487d168df9a378ea320a03 Revert virtio: drop virtio_queue_get_ring_{size, addr}()
+- 652d3f7579b4a34194dc2fcd4808322353d855fd Revert vfio/pci: Add support for mmapping MSI-X table
+
 * Wed Jan 25 2017 OpenPOWER Host OS Builds Bot <open-power-host-os-builds-bot@users.noreply.github.com> - 15:2.7.0-9
 - 169a53efae579f51022612577e7b17c8aead237c vfio/pci: Add support for mmapping
   MSI-X table

--- a/qemu/qemu.yaml
+++ b/qemu/qemu.yaml
@@ -3,4 +3,4 @@ Package:
   - git:
      src: 'https://github.com/open-power-host-os/qemu.git'
      branch: 'hostos-devel'
-     commit_id: '169a53efae579f51022612577e7b17c8aead237c'
+     commit_id: 'bb80805d7d5b14e886e769b5938b459a3592d882'

--- a/servicelog/CentOS/7/servicelog.spec
+++ b/servicelog/CentOS/7/servicelog.spec
@@ -1,9 +1,10 @@
 %global commit          7d33cd33507d6f11fb86c4bc13d752cb122759f7
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:           servicelog
 Version:        1.1.14
-Release:        4.git%{shortcommit}%{?dist}
+Release:        4%{gitcommittag}%{?dist}
 Summary:        Servicelog Tools
 
 Group:          System Environment/Base
@@ -107,5 +108,3 @@ of service operations that have been performed on the system.
 
 * Tue May 18 2010 Roman Rakus <rrakus@redhat.com> - 1.1.7-1
 - Initial packaging
-
-

--- a/sos/CentOS/7/sos.spec
+++ b/sos/CentOS/7/sos.spec
@@ -89,10 +89,10 @@ rm -rf ${RPM_BUILD_ROOT}
 
 * Wed Sep 17 2014 Bryn M. Reeves <bmr@redhat.com> = 3.2-beta1
 - New upstream beta release
- 
+
 * Thu Jun 12 2014 Bryn M. Reeves <bmr@redhat.com> = 3.2-alpha1
 - New upstream alpha release
- 
+
 * Mon Jan 27 2014 Bryn M. Reeves <bmr@redhat.com> = 3.1-1
 - New upstream release
 
@@ -221,7 +221,7 @@ rm -rf ${RPM_BUILD_ROOT}
 - Improve sanitization of RHN user and case number in report name
   Resolves: bz771393
 - Fix verbose output and debug logging
-  Resolves: bz782339 
+  Resolves: bz782339
 - Add basic support for CloudForms data collection
   Resolves: bz752666
 - Add support for Subscription Asset Manager diagnostics
@@ -266,7 +266,7 @@ rm -rf ${RPM_BUILD_ROOT}
 * Tue Nov  1 2011 Bryn M. Reeves <bmr@redhat.com> = 2.2-17
 - Do not collect subscription manager keys in general plugin
   Resolves: bz750607
- 
+
 * Fri Sep 23 2011 Bryn M. Reeves <bmr@redhat.com> = 2.2-16
 - Fix execution of RHN hardware.py from hardware plugin
   Resolves: bz736718
@@ -324,7 +324,7 @@ rm -rf ${RPM_BUILD_ROOT}
 * Thu Apr 07 2011 Bryn M. Reeves <bmr@redhat.com> = 2.2-8
 - Use sha256 for report digest when operating in FIPS mode
   Resolves: bz689387
- 
+
 * Tue Apr 05 2011 Bryn M. Reeves <bmr@redhat.com> = 2.2-7
 - Fix parted and dumpe2fs output on s390
   Resolves: bz622784
@@ -693,4 +693,3 @@ rm -rf ${RPM_BUILD_ROOT}
 
 * Mon May 22 2006 John Berninger <jwb at redhat dot com> - 0.1-1
 - initial package build
-

--- a/sos/CentOS/7/sos.spec
+++ b/sos/CentOS/7/sos.spec
@@ -1,12 +1,13 @@
 %global commit          52dd1dbc52783e622ca0a96e3e9c182bb26887fe
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 %{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Summary: A set of tools to gather troubleshooting information from a system
 Name: sos
 Version: 3.3
-Release: 18.git%{shortcommit}%{?dist}
+Release: 18%{gitcommittag}%{?dist}
 Group: Applications/System
 Source0: %{name}.tar.gz
 License: GPLv2+

--- a/wok/CentOS/7/wok.spec
+++ b/wok/CentOS/7/wok.spec
@@ -1,9 +1,10 @@
 %global commit          b0cf42955ce44d4981e14e9485872ecbea33edff
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 
 Name:       wok
 Version:    2.3.0
-Release:    11.git%{shortcommit}%{?dist}
+Release:    11%{gitcommittag}%{?dist}
 Summary:    Wok - Webserver Originated from Kimchi
 BuildRoot:  %{_topdir}/BUILD/%{name}-%{version}-%{release}
 BuildArch:  noarch


### PR DESCRIPTION
qemu had to be manually updated because its Makefile is not generating some doc files anymore.
The upgrade-versions script was incorrectly updating the release field when the package version was upgraded.