### PR TITLE
Prepare golang-github-* packages for release package requirements

### DIFF
--- a/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
+++ b/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
@@ -16,7 +16,7 @@
 
 Name:       golang-%{provider}-%{project}-%{repo}
 Version:    1.2
-Release:    5s%{gitcommittag}%{?dist}
+Release:    6%{gitcommittag}%{?dist}
 # Be ahead of Fedora
 Epoch:      1
 Summary:    Markdown processor implemented in Go
@@ -75,6 +75,9 @@ cp -pav testdata/* %{buildroot}%{gopath}/src/%{import_path}/testdata/
 %{gopath}/src/%{import_path}/*/*
 
 %changelog
+* Wed Feb 22 2017 Olav Philipp Henschel <olavph@linux.vnet.ibm.com> - 1.2-6.git5f33e7b
+- Remove extraneous letter from release number
+
 * Mon Mar 02 2015 jchaloup <jchaloup@redhat.com> - 1.2-5
 - Bump to upstream 77efab57b2f74dd3f9051c79752b2e8995c8b789
   Update spec file to used commit tarball

--- a/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
+++ b/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
@@ -29,6 +29,9 @@ BuildArch:  noarch
 ExclusiveArch:  %{ix86} x86_64 %{arm}
 %endif
 
+# This is required by the OpenPOWER Host OS release package
+Requires: %{name}-devel = %{epoch}:%{version}-%{release}
+
 %description
 %{summary}
 
@@ -60,6 +63,8 @@ cp -pav testdata/* %{buildroot}%{gopath}/src/%{import_path}/testdata/
 %if %{with tests}
 %check
 %endif
+
+%files
 
 %files devel
 %doc README.md

--- a/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
+++ b/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
@@ -28,6 +28,9 @@ BuildArch:      noarch
 ExclusiveArch:  %{ix86} x86_64 %{arm}
 %endif
 
+# This is required by the OpenPOWER Host OS release package
+Requires: %{name}-devel = %{epoch}:%{version}-%{release}
+
 %description
 %{summary}
 
@@ -56,6 +59,8 @@ cp -pav *.go %{buildroot}/%{gopath}/src/%{import_path}/
 %if %{with tests}
 %check
 %endif
+
+%files
 
 %files devel
 %doc README.md LICENSE

--- a/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
+++ b/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
@@ -11,7 +11,7 @@
 %global commit          1dba4b3954bc059efc3991ec364f9f9a35f597d2
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gccgo_version  >= 5
-%global golang_version >= 1.2.1-3 
+%global golang_version >= 1.2.1-3
 
 Name:           golang-%{provider}-%{project}-%{repo}
 Version:        0
@@ -34,14 +34,14 @@ ExclusiveArch:  %{ix86} x86_64 %{arm}
 %package devel
 
 BuildRequires: golang %{?golang_version}
-Requires: golang %{?golang_version} 
+Requires: golang %{?golang_version}
 Summary:        %{summary}
 Provides:       golang(%{import_path}) = %{version}-%{release}
 
 %description devel
 %{summary}
 
-This package contains library source intended for 
+This package contains library source intended for
 building other packages which use %{project}/%{repo}.
 
 %prep

--- a/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
+++ b/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
@@ -10,12 +10,13 @@
 %global import_path     %{provider}.%{provider_tld}/%{project}/%{repo}
 %global commit          1dba4b3954bc059efc3991ec364f9f9a35f597d2
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
+%global gitcommittag    .git%{shortcommit}
 %global gccgo_version  >= 5
 %global golang_version >= 1.2.1-3
 
 Name:           golang-%{provider}-%{project}-%{repo}
 Version:        0
-Release:        0.1.sgit%{shortcommit}%{?dist}
+Release:        1%{gitcommittag}%{?dist}
 # Be ahead of Fedora
 Epoch:          1
 Summary:        Package sanitized_anchor_name provides a func to create sanitized anchor names
@@ -68,6 +69,9 @@ cp -pav *.go %{buildroot}/%{gopath}/src/%{import_path}/
 %{gopath}/src/%{import_path}
 
 %changelog
+* Wed Feb 22 2017 Olav Philipp Henschel <olavph@linux.vnet.ibm.com> - 0-1.git1dba4b3
+- Remove extraneous letter and extra number from release
+
 * Thu Feb 26 2015 jchaloup <jchaloup@redhat.com> - 0-0.1.git8e87604
 - First package for Fedora
   resolves: #1196551


### PR DESCRIPTION
The packages golang-github-russross-blackfriday and
golang-github-shurcooL-sanitized_anchor_name need to provide a main
package and also a release bump to work with our idea of a Host OS release
package.