### PR TITLE
Make libservicelog a build dependency of servicelog

### DIFF
--- a/servicelog/servicelog.yaml
+++ b/servicelog/servicelog.yaml
@@ -10,5 +10,5 @@ Package:
  files:
   CentOS:
    '7':
-    install_dependencies:
+    build_dependencies:
      - 'libservicelog'


### PR DESCRIPTION
According to the servicelog rpm spec, libservicelog is a build
requirement, not an installation requirement. libservicelog
already exists in base distribution (CentOS), but we want to
use the customized version provided by OP Host OS, so we must
mention it explicitly in servicelog yaml.