### PR TITLE
Make libvpd a build dependency of lsvpd

### DIFF
--- a/lsvpd/lsvpd.yaml
+++ b/lsvpd/lsvpd.yaml
@@ -10,7 +10,6 @@ Package:
  files:
   CentOS:
    '7':
-    install_dependencies:
-     - 'libvpd'
     build_dependencies:
      - 'librtas'
+     - 'libvpd'


### PR DESCRIPTION
According to the lsvpd rpm spec, libvpd is a build
requirement, not an installation requirement. libvpd
already exists in base distribution (CentOS), but we want to
use the customized version provided by OP Host OS, so we must
mention it explicitly in servicelog yaml.