### PR TITLE
Obsolete qemu-kvm-ev and qemu-kvm-common-ev in qemu subpackages

### DIFF
--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -190,7 +190,7 @@
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 2.8.0
-Release: 2%{gitcommittag}%{?dist}
+Release: 3%{gitcommittag}%{?dist}
 Epoch: 15
 License: GPLv2+ and LGPLv2+ and BSD
 Group: Development/Tools
@@ -436,6 +436,7 @@ This package provides a command line tool for manipulating disk images
 %package  common
 Summary: QEMU common files needed by all QEMU targets
 Group: Development/Tools
+Obsoletes: qemu-kvm-common-ev
 %if %{with separate_kvm}
 Requires: qemu-kvm-common
 %endif
@@ -668,6 +669,7 @@ This package provides the system emulator for SPARC and SPARC64 systems.
 %package %{system_ppc}
 Summary: QEMU system emulator for PPC
 Group: Development/Tools
+Obsoletes: qemu-kvm-common-ev
 Requires: %{name}-common = %{epoch}:%{version}-%{release}
 #Requires: openbios
 #Requires: SLOF >= 0.1.git%{SLOF_gittagdate}
@@ -1531,6 +1533,9 @@ getent passwd qemu >/dev/null || \
 %endif
 
 %changelog
+* Tue Feb 28 2017 Murilo Opsfelder Araújo <muriloo@linux.vnet.ibm.com> - 15:2.8.0-3.gitbb80805
+- Obsolete qemu-kvm-common-ev in qemu-common and qemu-system-ppc subpackages
+
 * Mon Feb 27 2017 Murilo Opsfelder Araújo <muriloo@linux.vnet.ibm.com> - 15:2.8.0-2.gitbb80805
 - Obsolete qemu-kvm-ev in qemu-kvm subpackage
 

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -190,7 +190,7 @@
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 2.8.0
-Release: 1%{gitcommittag}%{?dist}
+Release: 2%{gitcommittag}%{?dist}
 Epoch: 15
 License: GPLv2+ and LGPLv2+ and BSD
 Group: Development/Tools
@@ -414,6 +414,7 @@ As QEMU requires no host kernel patches to run, it is safe and easy to use.
 Summary: QEMU metapackage for KVM support
 Group: Development/Tools
 Requires: qemu-%{kvm_package} = %{epoch}:%{version}-%{release}
+Obsoletes: qemu-kvm-ev
 %provide_rhev qemu-kvm
 
 %description kvm
@@ -1530,6 +1531,9 @@ getent passwd qemu >/dev/null || \
 %endif
 
 %changelog
+* Mon Feb 27 2017 Murilo Opsfelder Araújo <muriloo@linux.vnet.ibm.com> - 15:2.8.0-2.gitbb80805
+- Obsolete qemu-kvm-ev in qemu-kvm subpackage
+
 * Tue Feb 14 2017 Olav Philipp Henschel <olavph@linux.vnet.ibm.com> - 15:2.8.0-1.gitbb80805
 - Version update
 - Removed files qemu-tech.html and qmp-commands.txt that are not generated anymore


### PR DESCRIPTION
If qemu-kvm-ev or qemu-kvm-common-ev packages are installed and you try to install or update qemu-kvm, qemu-common, or qemu-system-ppc from Host OS, yum will fail with the following messages:

```
No update paths found for 10:qemu-kvm-ev-2.6.0-27.1.el7.ppc64le. Failure due to requirement: Package: 10:qemu-kvm-ev-2.6.0-27.1.el7.ppc64le (@extras)
    Requires: qemu-img-ev = 10:2.6.0-27.1.el7
    Removing: 10:qemu-img-ev-2.6.0-27.1.el7.ppc64le (@extras)
        qemu-img-ev = 10:2.6.0-27.1.el7
    Obsoleted By: 15:qemu-img-2.8.0-1.gitbb80805.el7.centos.ppc64le (hostos)
        Not found!
```

```
Transaction check error:
   file /usr/libexec/qemu-bridge-helper from install of qemu-common-15:2.8.0-2.gitbb80805.el7.centos.ppc64le conflicts with file from package qemu-kvm-common-ev-10:2.6.0-27.
   file /usr/share/man/man1/qemu-kvm.1.gz from install of qemu-system-ppc-15:2.8.0-2.gitbb80805.el7.centos.ppc64le conflicts with file from package qemu-kvm-common-ev-10:2.6
```

This pull request updates qemu.spec and obsoletes -ev packages in qemu subpackages.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>