### PR TITLE
Remove hardcoded commits from spec files

### DIFF
--- a/SLOF/CentOS/7/SLOF.spec
+++ b/SLOF/CentOS/7/SLOF.spec
@@ -1,4 +1,4 @@
-%global commit          1903174472f8800caf50c959b304501b4c01153c
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/crash/CentOS/7/crash.spec
+++ b/crash/CentOS/7/crash.spec
@@ -1,4 +1,4 @@
-%global commit          64531dc850f2840cedafa143fe051d2cfeae5247
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/docker-swarm/CentOS/7/docker-swarm.spec
+++ b/docker-swarm/CentOS/7/docker-swarm.spec
@@ -15,7 +15,7 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-%global commit          a0fd82b90932741bda54245e990df433a9ee06a7
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/docker/CentOS/7/docker.spec
+++ b/docker/CentOS/7/docker.spec
@@ -32,7 +32,7 @@
 
 # docker
 %global git0 https://github.com/projectatomic/%{repo}
-%global commit0 bb80604a0b200140a440675348c848a137a1b2e2
+%global commit0 %{?git_commit_id}
 %global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
 # docker_branch used in %%check
 %global docker_branch docker-1.12

--- a/flannel/CentOS/7/flannel.spec
+++ b/flannel/CentOS/7/flannel.spec
@@ -18,7 +18,7 @@
 %global project         coreos
 %global repo            flannel
 %global import_path     %{provider}.%{provider_tld}/%{project}/%{repo}
-%global commit          cb8284fb60737793596dd2fc98d9608d3d0d66f0
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/gcc/CentOS/7/gcc.spec
+++ b/gcc/CentOS/7/gcc.spec
@@ -3,7 +3,7 @@
 %bcond_with tests
 
 %global DATE 20150702
-%global SVNREV 240558
+%global SVNREV %{svn_revision}
 # Note, gcc_release must be integer, if you want to add suffixes to
 # %{release}, append them after %{gcc_release} on Release: line.
 %global gcc_release 12

--- a/ginger-base/CentOS/7/ginger-base.spec
+++ b/ginger-base/CentOS/7/ginger-base.spec
@@ -2,7 +2,7 @@
 %global with_systemd 1
 %endif
 
-%global commit          109815ccb5bbcbdc5dc5cef847accf9a3b9083d4
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/ginger/CentOS/7/ginger.spec
+++ b/ginger/CentOS/7/ginger.spec
@@ -1,4 +1,4 @@
-%global commit          e9b8a1bf149d1f2b45b618e6897c96d23c52c373
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
+++ b/golang-github-russross-blackfriday/CentOS/7/golang-github-russross-blackfriday.spec
@@ -8,7 +8,7 @@
 %global project         russross
 %global repo            blackfriday
 %global import_path     %{provider}.%{provider_tld}/%{project}/%{repo}
-%global commit          5f33e7b7878355cd2b7e6b8eefc48a5472c69f70
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 %global gccgo_version  >= 5

--- a/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
+++ b/golang-github-shurcooL-sanitized_anchor_name/CentOS/7/golang-github-shurcooL-sanitized_anchor_name.spec
@@ -8,7 +8,7 @@
 %global project         shurcooL
 %global repo            sanitized_anchor_name
 %global import_path     %{provider}.%{provider_tld}/%{project}/%{repo}
-%global commit          1dba4b3954bc059efc3991ec364f9f9a35f597d2
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 %global gccgo_version  >= 5

--- a/hwdata/CentOS/7/hwdata.spec
+++ b/hwdata/CentOS/7/hwdata.spec
@@ -1,4 +1,4 @@
-%global commit          625a1194eaf9b764985ebec3a5da78dc71299238
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/kernel/CentOS/7/kernel.spec
+++ b/kernel/CentOS/7/kernel.spec
@@ -1,4 +1,4 @@
-%global commit          fb71deab42a6d5f6dd631386f0defc954ad7eb19
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/kimchi/CentOS/7/kimchi.spec
+++ b/kimchi/CentOS/7/kimchi.spec
@@ -1,4 +1,4 @@
-%global commit          3830c259b7628028dddac3a55aeb33ea964bae2b
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/kubernetes/CentOS/7/kubernetes.spec
+++ b/kubernetes/CentOS/7/kubernetes.spec
@@ -37,7 +37,7 @@
 # https://github.com/kubernetes/kubernetes
 %global k8s_provider_prefix %{k8s_provider}.%{k8s_provider_tld}/%{k8s_project}/%{k8s_repo}
 # commit picked from openshift/kubernetes although it is available on kubernetes/kubernetes as well
-%global k8s_commit      4a3f9c5b19c7ff804cbc1bf37a15c044ca5d2353
+%global k8s_commit      %{?git_commit_id}
 %global k8s_shortcommit %(c=%{k8s_commit}; echo ${c:0:7})
 %global k8s_src_dir     Godeps/_workspace/src/k8s.io/kubernetes/
 %global k8s_src_dir_sed Godeps\\/_workspace\\/src\\/k8s\\.io\\/kubernetes\\/

--- a/librtas/CentOS/7/librtas.spec
+++ b/librtas/CentOS/7/librtas.spec
@@ -1,4 +1,4 @@
-%global commit          3fe4911fa9e456e6cae2f314cff46894025b7fb9
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/libservicelog/CentOS/7/libservicelog.spec
+++ b/libservicelog/CentOS/7/libservicelog.spec
@@ -1,4 +1,4 @@
-%global commit          48875ee8614eeefaa3d5d8ff92fb424915738169
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/libvirt/CentOS/7/libvirt.spec
+++ b/libvirt/CentOS/7/libvirt.spec
@@ -1,4 +1,4 @@
-%global commit          ddccbf6072a3f95e053cc9934d1178cb1acd2aa7
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/libvpd/CentOS/7/libvpd.spec
+++ b/libvpd/CentOS/7/libvpd.spec
@@ -1,4 +1,4 @@
-%global commit          8cb3fe06b8d2e6125235eb1973e624a0fb12837c
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/lshw/CentOS/7/lshw.spec
+++ b/lshw/CentOS/7/lshw.spec
@@ -1,7 +1,7 @@
 # Conditional build (--with/--without option)
 #   --without gui
 
-%global commit f9bdcc342d525f8504b81a9a344d58f57aa9b5dc
+%global commit %{?git_commit_id}
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag .git%{shortcommit}
 

--- a/lsvpd/CentOS/7/lsvpd.spec
+++ b/lsvpd/CentOS/7/lsvpd.spec
@@ -1,4 +1,4 @@
-%global commit          3a5f5e1fdf82ebc6efdda4cfc51fd24776bad8be
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/novnc/CentOS/7/novnc.spec
+++ b/novnc/CentOS/7/novnc.spec
@@ -1,4 +1,4 @@
-%global commit          fc00821eba469641c6c94706726c3d78e46460a2
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/ppc64-diag/CentOS/7/ppc64-diag.spec
+++ b/ppc64-diag/CentOS/7/ppc64-diag.spec
@@ -1,4 +1,4 @@
-%global commit          d56f7f1367bd6634605fd65997170252696178fa
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -1,4 +1,4 @@
-%global commit          27ddb62b6526f44c9eff0797ba49b1b14f122f07
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/servicelog/CentOS/7/servicelog.spec
+++ b/servicelog/CentOS/7/servicelog.spec
@@ -1,4 +1,4 @@
-%global commit          7d33cd33507d6f11fb86c4bc13d752cb122759f7
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/sos/CentOS/7/sos.spec
+++ b/sos/CentOS/7/sos.spec
@@ -1,4 +1,4 @@
-%global commit          52dd1dbc52783e622ca0a96e3e9c182bb26887fe
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 

--- a/wok/CentOS/7/wok.spec
+++ b/wok/CentOS/7/wok.spec
@@ -1,4 +1,4 @@
-%global commit          7f5e0aea58ce406eccbaa46d6326ab883154950d
+%global commit          %{?git_commit_id}
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 


### PR DESCRIPTION
Depends on https://github.com/open-power-host-os/builds/pull/224

The commit IDs are now only in YAML files.