### PR TITLE
Revert hwdata's commit ID in spec file

### DIFF
--- a/hwdata/CentOS/7/hwdata.spec
+++ b/hwdata/CentOS/7/hwdata.spec
@@ -1,4 +1,4 @@
-%global commit          %{?git_commit_id}
+%global commit          625a1194eaf9b764985ebec3a5da78dc71299238
 %global shortcommit     %(c=%{commit}; echo ${c:0:7})
 %global gitcommittag    .git%{shortcommit}
 


### PR DESCRIPTION
Currently, this package does not have an available git repository and
so it's commit ID is not in the YAML file.

Regression introduced in commit 5b8a44fc3baaf5969c084ac6c5c6a564ec5c55b1