### PR TITLE
Add openvswitch selinux policy (#226)

### DIFF
--- a/open-power-host-os/CentOS/7/SOURCES/hostos-openvswitch.te
+++ b/open-power-host-os/CentOS/7/SOURCES/hostos-openvswitch.te
@@ -1,0 +1,9 @@
+module hostos-openvswitch 0.1;
+
+require {
+        type openvswitch_t;
+        class netlink_generic_socket { ioctl read write create getattr setattr lock append bind connect getopt setopt shutdown };
+}
+
+#============= openvswitch_t ==============
+allow openvswitch_t self:netlink_generic_socket { ioctl read write create getattr setattr lock append bind connect getopt setopt shutdown };


### PR DESCRIPTION
This change adds a new selinux policy named `hostos-openvswitch` that
allows openvswitch to create generic netlink sockets.

Fixes https://github.com/open-power-host-os/builds/issues/226

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>