### PR TITLE
Use gcc copy from open-power-host-os organization at GitHub

### DIFF
--- a/gcc/CentOS/7/gcc.spec
+++ b/gcc/CentOS/7/gcc.spec
@@ -3,7 +3,9 @@
 %bcond_with tests
 
 %global DATE 20150702
-%global SVNREV %{svn_revision}
+# Hard-code SVNREV here because we are using a copy of gcc from a git
+# repository, which contains a copy of the specified svn revision.
+%global SVNREV 240558
 # Note, gcc_release must be integer, if you want to add suffixes to
 # %{release}, append them after %{gcc_release} on Release: line.
 %global gcc_release 12

--- a/gcc/gcc.yaml
+++ b/gcc/gcc.yaml
@@ -1,11 +1,11 @@
 Package:
  name: 'gcc'
  sources:
-  - svn:
+  - git:
      # gcc 4.8.5-20150702
-     src: 'svn://gcc.gnu.org/svn/gcc/branches/redhat/gcc-4_8-branch'
-     commit_id: '240558'
-     branch: 'redhat/gcc-4_8-branch'
+     src: 'https://github.com/open-power-host-os/gcc.git'
+     branch: 'redhat/gcc-4_8-branch@240558'
+     commit_id: '79a21739f1484185ecea2200ccb172e129ab4073'
  files:
   CentOS:
    '7':


### PR DESCRIPTION
Depends on https://github.com/open-power-host-os/builds/pull/241

It is not rare that builds got stuck at svn checkout.  From time to
time, the svn checkout from gcc.gnu.org terminates with error:

$ svn checkout svn://gcc.gnu.org/svn/gcc/branches/redhat/gcc-4_8-branch@240558 gcc-4_8-branch
svn: E210002: Unable to connect to a repository at URL 'svn://gcc.gnu.org/svn/gcc/branches/redhat/gcc-4_8-branch'
svn: E210002: Network connection closed unexpectedly

This patch configures gcc.yaml to download code from a gcc copy placed
at GitHub under open-power-host-os organization.  Hopefully, builds
will not get stuck at code checkout anymore.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>