### PR TITLE
Checkout from master branch in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 node('master') {
   dir('infrastructure') {
     git(url: 'https://github.com/open-power-host-os/infrastructure.git',
-        branch: 'pipeline')
+        branch: 'master')
   }
   pipeline = load 'infrastructure/pipeline/build.groovy'
 }


### PR DESCRIPTION
The previous branch "pipeline" was only temporary.