### PR TITLE
kernel.spec: Fix gcc-check-mprofile-kernel.sh path

### DIFF
--- a/kernel/CentOS/7/kernel.spec
+++ b/kernel/CentOS/7/kernel.spec
@@ -1404,8 +1404,8 @@ touch -a %{SOURCE2001}
 %endif
 
 %ifnarch noarch
- mkdir -p $RPM_BUILD_ROOT/usr/src/kernels/%{KVRA}%{?2:.%{2}}/arch/powerpc/scripts
- install -m 0755  arch/powerpc/scripts/gcc-check-mprofile-kernel.sh $RPM_BUILD_ROOT/usr/src/kernels/%{KVRA}%{?2:.%{2}}/arch/powerpc/scripts/gcc-check-mprofile-kernel.sh
+ mkdir -p $RPM_BUILD_ROOT/usr/src/kernels/%{KVRA}%{?2:.%{2}}/arch/powerpc/tools
+ install -m 0755  arch/powerpc/tools/gcc-check-mprofile-kernel.sh $RPM_BUILD_ROOT/usr/src/kernels/%{KVRA}%{?2:.%{2}}/arch/powerpc/tools/gcc-check-mprofile-kernel.sh
 %endif
 
 ###


### PR DESCRIPTION
The following upstream commit renamed
arch/powerpc/{scripts -> tools}/gcc-check-mprofile-kernel.sh:

commit b71c9ffb140556004caf7ba27083f9d90ae8d14b
Author: Nicholas Piggin <npiggin@gmail.com>
Date:   Sat Nov 26 14:26:10 2016 +1100

    powerpc: Add arch/powerpc/tools directory

This fixes the path in kernel.spec.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>