### PR TITLE
Change milestone to "dev"

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 # format: <version>[-alpha|-beta]
-3.0-alpha
+3.0-dev


### PR DESCRIPTION
The development branch will no longer change milestones over time.
It will keep a constant "dev" milestone to differentiate from release
builds.