### PR TITLE
qemu 2.10 backports for hostos-release

### DIFF
--- a/open-power-host-os/CentOS/7/open-power-host-os.spec
+++ b/open-power-host-os/CentOS/7/open-power-host-os.spec
@@ -61,7 +61,7 @@ Requires(post): skopeo = 0.1.20-3%{?extraver}.gite802625%{dist}
 Requires: %{name}-virt = %{version}-%{release}
 Requires(post): SLOF = 20170724-1%{?extraver}.git685af54%{dist}
 Requires(post): libvirt = 3.6.0-2%{?extraver}.git40c1264%{dist}
-Requires(post): qemu = 15:2.9.0-7%{?extraver}.git4cfb657%{dist}
+Requires(post): qemu = 15:2.10.0-1%{?extraver}.gitc334a4e%{dist}
 Requires: %{name}-ras = %{version}-%{release}
 Requires(post): crash = 7.1.6-3%{?extraver}.git64531dc%{dist}
 Requires(post): hwdata = 0.288-3%{?extraver}.git625a119%{dist}
@@ -126,7 +126,7 @@ Requires(post): kernel = 4.13.0-3.rc3%{?extraver}.gitec0d270%{dist}
 
 Requires(post): SLOF = 20170724-1%{?extraver}.git685af54%{dist}
 Requires(post): libvirt = 3.6.0-2%{?extraver}.git40c1264%{dist}
-Requires(post): qemu = 15:2.9.0-7%{?extraver}.git4cfb657%{dist}
+Requires(post): qemu = 15:2.10.0-1%{?extraver}.gitc334a4e%{dist}
 
 %description virt
 %{summary}

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -189,8 +189,8 @@
 
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
-Version: 2.9.0
-Release: 7%{?extraver}%{gitcommittag}%{?dist}
+Version: 2.10.0
+Release: 1%{?extraver}%{gitcommittag}%{?dist}
 Epoch: 15
 License: GPLv2+ and LGPLv2+ and BSD
 Group: Development/Tools
@@ -1068,6 +1068,9 @@ rm -rf $RPM_BUILD_ROOT%{_includedir}/cacard
 rm -f $RPM_BUILD_ROOT%{_libexecdir}/qemu-bridge-helper
 %endif
 
+# Remove unpackaged files
+%{__rm} -f %{buildroot}%{_datadir}/%{name}/s390-netboot.img
+
 # When building using 'rpmbuild' or 'fedpkg local', RPATHs can be left in
 # the binaries and libraries (although this doesn't occur when
 # building in Koji, for some unknown reason). Some discussion here:
@@ -1169,7 +1172,6 @@ getent passwd qemu >/dev/null || \
 
 %files common
 %defattr(-, root, root)
-/etc/qemu
 /usr/bin/ivshmem-client
 /usr/bin/ivshmem-server
 /usr/share/man/man8/qemu-ga.8.gz
@@ -1309,6 +1311,7 @@ getent passwd qemu >/dev/null || \
 %{_datadir}/%{name}/vgabios-qxl.bin
 %{_datadir}/%{name}/vgabios-stdvga.bin
 %{_datadir}/%{name}/vgabios-vmware.bin
+%{_datadir}/%{name}/qemu_vga.ndrv
 %{_datadir}/%{name}/pxe-e1000.rom
 %{_datadir}/%{name}/efi-e1000.rom
 %{_datadir}/%{name}/efi-e1000e.rom
@@ -1543,6 +1546,9 @@ getent passwd qemu >/dev/null || \
 %endif
 
 %changelog
+* Mon Sep 04 2017 Murilo Opsfelder Araújo <muriloo@linux.vnet.ibm.com> - 15:2.10.0-1.git
+- Update to qemu 2.10.0
+
 * Mon Aug 14 2017 Olav Philipp Henschel <olavph@linux.vnet.ibm.com> - 15:2.9.0-7.git
 - Bump release
 

--- a/qemu/qemu.yaml
+++ b/qemu/qemu.yaml
@@ -3,4 +3,4 @@ Package:
   - git:
      src: 'https://github.com/open-power-host-os/qemu.git'
      branch: 'hostos-release'
-     commit_id: '4cfb65715e5285202d53b030b24b9d20200e45d1'
+     commit_id: 'c334a4eee787fb8e9874b713b8c9ca35ee1e557a'


### PR DESCRIPTION
These two commits come from hostos-devel and are required to build qemu 2.10 from hostos-release.