### PR TITLE
Update to systemtap 3.2

### DIFF
--- a/open-power-host-os/CentOS/7/open-power-host-os.spec
+++ b/open-power-host-os/CentOS/7/open-power-host-os.spec
@@ -5,7 +5,7 @@
 
 Name: open-power-host-os
 Version: 3.5
-Release: 3%{?milestone_tag}%{dist}
+Release: 4%{?milestone_tag}%{dist}
 Summary: OpenPOWER Host OS metapackages
 Group: System Environment/Base
 License: GPLv3
@@ -71,7 +71,7 @@ Requires(post): lsvpd = 1.7.8-3%{?extraver}.gitc36b20b%{dist}
 Requires(post): ppc64-diag = 2.7.4-3%{?extraver}.git608507e%{dist}
 Requires(post): servicelog = 1.1.14-8%{?extraver}.git3955e85%{dist}
 Requires(post): sos
-Requires(post): systemtap = 3.1-5%{?extraver}.git39b62b4%{dist}
+Requires(post): systemtap = 3.2-1%{?extraver}.git4051c70%{dist}
 
 Requires(post): gcc = 4.8.5-17%{?extraver}.svn240558%{dist}
 Requires(post): golang-github-russross-blackfriday = 1:1.2-8%{?extraver}.git5f33e7b%{dist}
@@ -143,7 +143,7 @@ Requires(post): lsvpd = 1.7.8-3%{?extraver}.gitc36b20b%{dist}
 Requires(post): ppc64-diag = 2.7.4-3%{?extraver}.git608507e%{dist}
 Requires(post): servicelog = 1.1.14-8%{?extraver}.git3955e85%{dist}
 Requires(post): sos
-Requires(post): systemtap = 3.1-5%{?extraver}.git39b62b4%{dist}
+Requires(post): systemtap = 3.2-1%{?extraver}.git4051c70%{dist}
 
 %description ras
 %{summary}
@@ -210,6 +210,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Tue Oct 31 2017 Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com> - 3.5-4.dev
+- Update deps to systemtap 3.2
+
 * Sat Oct 21 2017 OpenPOWER Host OS Builds Bot <open-power-host-os-builds-bot@users.noreply.github.com> - 3.5-3.dev
 - Update package dependencies
 

--- a/systemtap/CentOS/7/systemtap.spec
+++ b/systemtap/CentOS/7/systemtap.spec
@@ -75,8 +75,8 @@
 %global gitcommittag    .git%{shortcommit}
 
 Name: systemtap
-Version: 3.1
-Release: 5%{?extraver}%{?gitcommittag}%{?dist}
+Version: 3.2
+Release: 1%{?extraver}%{?gitcommittag}%{?dist}
 # for version, see also configure.ac
 
 
@@ -1143,6 +1143,9 @@ done
 
 # PRERELEASE
 %changelog
+* Tue Oct 31 2017 Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com> - 3.2-1
+- Update to systemtap 3.2
+
 * Mon Aug 14 2017 Olav Philipp Henschel <olavph@linux.vnet.ibm.com> - 3.1-5.git
 - Bump release
 

--- a/systemtap/systemtap.yaml
+++ b/systemtap/systemtap.yaml
@@ -3,4 +3,4 @@ Package:
   - git:
      src: 'git://sourceware.org/git/systemtap.git'
      branch: 'master'
-     commit_id: '39b62b4e3d10961ccab009e708f406a6fddec3a2' # release-3.1-90-g39b62b4
+     commit_id: '4051c70c9318c837981384cbb23f3e9eb1bd0892' # release-3.2


### PR DESCRIPTION
This updates systemtap.spec to version 3.2 and dependencies of
open-power-host-os.spec.

Fix https://github.com/open-power-host-os/linux/issues/21