### PR TITLE
kernel.spec: Add openssl-devel as BuildRequires

### DIFF
--- a/kernel/CentOS/7/kernel.spec
+++ b/kernel/CentOS/7/kernel.spec
@@ -363,6 +363,7 @@ BuildRequires: gcc >= 3.4.2, binutils >= 2.12, system-rpm-config >= 9.1.0-55
 BuildRequires: hostname, net-tools, bc
 BuildRequires: xmlto, asciidoc
 BuildRequires: openssl
+BuildRequires: openssl-devel
 %{!?cross_build:BuildRequires: hmaccalc}
 %{!?cross_build:BuildRequires: python-devel, perl(ExtUtils::Embed)}
 BuildRequires: newt-devel


### PR DESCRIPTION
Newer kernels, e.g.: 4.15-rc8, break with the following error:

    scripts/extract-cert.c:21:25: fatal error: openssl/bio.h: No such file or directory
     #include <openssl/bio.h>
                         ^

This patch fixes it by adding openssl-devel as BuildRequires, so the
openssl/bio.h header file will be available at build time.

(cherry picked from commit ee9856ba91783748dc5cfb5e12d15a20439ca4c1)