### PR TITLE
Remove skiboot.lid from qemu package

### DIFF
--- a/open-power-host-os/CentOS/7/open-power-host-os.spec
+++ b/open-power-host-os/CentOS/7/open-power-host-os.spec
@@ -5,7 +5,7 @@
 
 Name: open-power-host-os
 Version: 3.5
-Release: 23%{?milestone_tag}%{dist}
+Release: 24%{?milestone_tag}%{dist}
 Summary: OpenPOWER Host OS metapackages
 Group: System Environment/Base
 License: GPLv3
@@ -59,7 +59,7 @@ Requires(post): kubernetes = 1.2.0-0.23%{?extraver}.git4a3f9c5%{dist}
 Requires: %{name}-virt = %{version}-%{release}
 Requires(post): SLOF = 20170724-2%{?extraver}.gitea31295%{dist}
 Requires(post): libvirt = 4.0.0-2%{?extraver}.git5e6f8a1%{dist}
-Requires(post): qemu = 15:2.11.50-2%{?extraver}.git59cc362%{dist}
+Requires(post): qemu = 15:2.11.50-3%{?extraver}.git59cc362%{dist}
 Requires: %{name}-ras = %{version}-%{release}
 Requires(post): crash
 Requires(post): hwdata = 0.288-3%{?extraver}.git625a119%{dist}
@@ -121,7 +121,7 @@ Requires(post): kernel = 4.15.0-5%{?extraver}.git33f711f%{dist}
 
 Requires(post): SLOF = 20170724-2%{?extraver}.gitea31295%{dist}
 Requires(post): libvirt = 4.0.0-2%{?extraver}.git5e6f8a1%{dist}
-Requires(post): qemu = 15:2.11.50-2%{?extraver}.git59cc362%{dist}
+Requires(post): qemu = 15:2.11.50-3%{?extraver}.git59cc362%{dist}
 
 %description virt
 %{summary}
@@ -213,6 +213,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Mon Mar 05 2018 Fabiano Rosas <farosas@linux.vnet.ibm.com> - 3.5-24.dev
+- Update package dependencies
+
 * Mon Mar 05 2018 Fabiano Rosas <farosas@linux.vnet.ibm.com> - 3.5-23.dev
 - Update package dependencies
 

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -190,7 +190,7 @@
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 2.11.50
-Release: 2%{?extraver}%{gitcommittag}%{?dist}
+Release: 3%{?extraver}%{gitcommittag}%{?dist}
 Epoch: 15
 License: GPLv2+ and LGPLv2+ and BSD
 Group: Development/Tools
@@ -900,6 +900,8 @@ rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/openbios-sparc32
 rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/openbios-sparc64
 # Provided by package SLOF
 rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/slof.bin
+# Provided by package opal-firmware
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/skiboot.lid
 
 # Remove possibly unpackaged files.  Unlike others that are removed
 # unconditionally, these firmware files are still distributed as a binary
@@ -1334,7 +1336,6 @@ getent passwd qemu >/dev/null || \
 %{_datadir}/%{name}/efi-rtl8139.rom
 %{_datadir}/%{name}/pxe-ne2k_pci.rom
 %{_datadir}/%{name}/efi-ne2k_pci.rom
-%{_datadir}/%{name}/skiboot.lid
 #%config(noreplace) %{_sysconfdir}/qemu/target-x86_64.conf
 %{_datadir}/%{name}/qemu-icon.bmp
 %if %{without separate_kvm}
@@ -1557,6 +1558,9 @@ getent passwd qemu >/dev/null || \
 %endif
 
 %changelog
+* Mon Mar 05 2018 Fabiano Rosas <farosas@linux.vnet.ibm.com> - 15:2.11.50-3.git
+- Avoid conflict with opal-firmware package
+
 * Fri Feb 09 2018 OpenPOWER Host OS Builds Bot <open-power-host-os-builds-bot@users.noreply.github.com> - 15:2.11.50-2.git
 - Updating to 59cc362 spapr: add missing break in h_get_cpu_characteristics()
 


### PR DESCRIPTION
The skiboot.lid file is provided by the opal-firmware package. It doesn't need to be present in the qemu installation.

Since we now provide the opal-firmware package, that file was in conflict between the two packages.

Fixes open-power-host-os/builds#307