### PR TITLE
Revert qemu-system-x86 removal

### DIFF
--- a/open-power-host-os/CentOS/7/open-power-host-os.spec
+++ b/open-power-host-os/CentOS/7/open-power-host-os.spec
@@ -5,7 +5,7 @@
 
 Name: open-power-host-os
 Version: 3.5
-Release: 33%{?milestone_tag}%{dist}
+Release: 34%{?milestone_tag}%{dist}
 Summary: OpenPOWER Host OS metapackages
 Group: System Environment/Base
 License: GPLv3
@@ -59,7 +59,7 @@ Requires(post): kubernetes = 1.2.0-0.23%{?extraver}.git4a3f9c5%{dist}
 Requires: %{name}-virt = %{version}-%{release}
 Requires(post): SLOF = 20171214-2%{?extraver}.gitc2a331f%{dist}
 Requires(post): libvirt = 4.2.0-2%{?extraver}.gitbf217de%{dist}
-Requires(post): qemu = 15:2.12.0-1%{?extraver}.gitd36f3ee%{dist}
+Requires(post): qemu = 15:2.12.0-2%{?extraver}.gitd36f3ee%{dist}
 Requires: %{name}-ras = %{version}-%{release}
 Requires(post): crash
 Requires(post): hwdata = 0.288-3%{?extraver}.git625a119%{dist}
@@ -120,7 +120,7 @@ Requires(post): kernel = 4.16.0-3%{?extraver}.gitfd8742e%{dist}
 
 Requires(post): SLOF = 20171214-2%{?extraver}.gitc2a331f%{dist}
 Requires(post): libvirt = 4.2.0-2%{?extraver}.gitbf217de%{dist}
-Requires(post): qemu = 15:2.12.0-1%{?extraver}.gitd36f3ee%{dist}
+Requires(post): qemu = 15:2.12.0-2%{?extraver}.gitd36f3ee%{dist}
 
 %description virt
 %{summary}
@@ -211,6 +211,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Tue May 15 2018 Fabiano Rosas <farosas@linux.ibm.com> - 3.5-34.dev
+- Update package dependencies
+
 * Tue May 15 2018 OpenPOWER Host OS Builds Bot <open-power-host-os-builds-bot@users.noreply.github.com> - 3.5-33.dev
 - Update package dependencies
 

--- a/qemu/CentOS/7/qemu.spec
+++ b/qemu/CentOS/7/qemu.spec
@@ -190,7 +190,7 @@
 Summary: QEMU is a FAST! processor emulator
 Name: qemu
 Version: 2.12.0
-Release: 1%{?extraver}%{gitcommittag}%{?dist}
+Release: 2%{?extraver}%{gitcommittag}%{?dist}
 Epoch: 15
 License: GPLv2+ and LGPLv2+ and BSD
 Group: Development/Tools
@@ -518,8 +518,6 @@ Provides: kvm = 85
 Obsoletes: kvm < 85
 Requires: seavgabios-bin
 # First version that ships bios-256k.bin
-#Requires: seabios-bin >= 1.7.4-3
-Requires: sgabios-bin
 #Requires: ipxe-roms-qemu >= 20130517-2.gitc4bce43
 Requires: ipxe-roms-qemu
 %if 0%{?have_seccomp:1}
@@ -959,7 +957,7 @@ rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/vgabios-virtio.bin
 #rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/bios-256k.bin
 #rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/q35-acpi-dsdt.aml
 # Provided by package sgabios
-#rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/sgabios.bin
+rm -rf ${RPM_BUILD_ROOT}%{_datadir}/%{name}/sgabios.bin
 
 %if 0%{?system_x86:1}
 # the pxe gpxe images will be symlinks to the images on
@@ -988,7 +986,7 @@ rom_link() {
 #rom_link ../seabios/bios.bin bios.bin
 #rom_link ../seabios/bios-256k.bin bios-256k.bin
 #rom_link ../seabios/q35-acpi-dsdt.aml q35-acpi-dsdt.aml
-#rom_link ../sgabios/sgabios.bin sgabios.bin
+rom_link ../sgabios/sgabios.bin sgabios.bin
 %endif
 
 %if 0%{?user:1}
@@ -1561,6 +1559,9 @@ getent passwd qemu >/dev/null || \
 %endif
 
 %changelog
+* Tue May 15 2018 Fabiano Rosas <farosas@linux.ibm.com> - 15:2.12.0-2.git
+- Remove dependency on sgabios RPM which is not present in CentOS 7.5
+
 * Tue May 15 2018 OpenPOWER Host OS Builds Bot <open-power-host-os-builds-bot@users.noreply.github.com> - 15:2.12.0-1.git
 - Version update
 - Updating to d36f3ee Merge tag v2.12.0 into hostos-devel


### PR DESCRIPTION
The qemu-system-x86 removal is premature, we found out that some files required in ppc are packaged under x86 so it's best to just revert that removal and work our way into moving the appropriate files to qemu-common in a incremental way.